### PR TITLE
Card changes

### DIFF
--- a/assets/card-data.json
+++ b/assets/card-data.json
@@ -1928,7 +1928,8 @@
     "rarity": 1,
     "benefits": [
       "or spy",
-      "or return a spy 3 money, focus: 1 attack"
+      "or return a spy 3 money",
+      "focus: 1 attack"
     ],
     "effectKey": "howling-hatred-cultist",
     "_matchedSheet": true
@@ -1946,7 +1947,8 @@
     "rarity": 1,
     "benefits": [
       "or spy",
-      "or return a spy 3 money, focus: 1 attack"
+      "or return a spy 3 money",
+      "focus: 1 attack"
     ],
     "effectKey": "howling-hatred-cultist",
     "_matchedSheet": true

--- a/assets/card-data.json
+++ b/assets/card-data.json
@@ -3096,7 +3096,7 @@
     "type": "Grimlock",
     "rarity": 2,
     "benefits": [
-      "deploy 2 troops",
+      "deploy 1 troop",
       "if your opponent causes you to discard this, draw 2"
     ],
     "effectKey": "grimlock",

--- a/assets/card-data.json
+++ b/assets/card-data.json
@@ -11,7 +11,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "Supplant white troop"
+      "supplant white troop"
     ],
     "effectKey": "advance-scout",
     "_matchedSheet": true
@@ -28,7 +28,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "Supplant white troop"
+      "supplant white troop"
     ],
     "effectKey": "advance-scout",
     "_matchedSheet": true
@@ -45,7 +45,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "Supplant white troop"
+      "supplant white troop"
     ],
     "effectKey": "advance-scout",
     "_matchedSheet": true
@@ -62,8 +62,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "2 money",
-      "eot promote a card"
+      "or +2 money",
+      "or eot promote a card"
     ],
     "effectKey": "advocate",
     "_matchedSheet": true
@@ -80,8 +80,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "2 money",
-      "eot promote a card"
+      "or +2 money",
+      "or eot promote a card"
     ],
     "effectKey": "advocate",
     "_matchedSheet": true
@@ -98,8 +98,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "2 money",
-      "eot promote a card"
+      "or +2 money",
+      "or eot promote a card"
     ],
     "effectKey": "advocate",
     "_matchedSheet": true
@@ -116,8 +116,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "2 money",
-      "eot promote a card"
+      "or +2 money",
+      "or eot promote a card"
     ],
     "effectKey": "advocate",
     "_matchedSheet": true
@@ -134,8 +134,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or assassinate"
+      "or +2 attack",
+      "or assassinate a troop"
     ],
     "effectKey": "blackguard",
     "_matchedSheet": true
@@ -152,8 +152,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or assassinate"
+      "or +2 attack",
+      "or assassinate a troop"
     ],
     "effectKey": "blackguard",
     "_matchedSheet": true
@@ -170,8 +170,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or assassinate"
+      "or +2 attack",
+      "or assassinate a troop"
     ],
     "effectKey": "blackguard",
     "_matchedSheet": true
@@ -188,8 +188,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or assassinate"
+      "or +2 attack",
+      "or assassinate a troop"
     ],
     "effectKey": "blackguard",
     "_matchedSheet": true
@@ -206,7 +206,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "3 atk"
+      "+3 attack"
     ],
     "effectKey": "bounty-hunter",
     "_matchedSheet": true
@@ -223,7 +223,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "3 atk"
+      "+3 attack"
     ],
     "effectKey": "bounty-hunter",
     "_matchedSheet": true
@@ -240,7 +240,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "return troop or spy",
+      "return another player's troop/spy",
       "eot promote a card played"
     ],
     "effectKey": "chosen-of-lolth",
@@ -258,7 +258,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "return troop or spy",
+      "return another player's troop/spy",
       "eot promote a card played"
     ],
     "effectKey": "chosen-of-lolth",
@@ -276,7 +276,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "move 2 enemy troops",
+      "move up to 2 enemy troops",
       "eot promote played card"
     ],
     "effectKey": "council-member",
@@ -311,7 +311,7 @@
     "type": "Doppleganger",
     "rarity": 1,
     "benefits": [
-      "supplant"
+      "supplant a troop"
     ],
     "effectKey": "doppelganger",
     "_matchedSheet": true
@@ -328,7 +328,7 @@
     "type": "Doppleganger",
     "rarity": 1,
     "benefits": [
-      "supplant"
+      "supplant a troop"
     ],
     "effectKey": "doppelganger",
     "_matchedSheet": true
@@ -345,7 +345,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "If there are 4+ cards promoted, gain 3 money.",
+      "If there are 4+ cards promoted, +3 money.",
       "eot promote a card played this turn"
     ],
     "effectKey": "drow-negotiator",
@@ -363,7 +363,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "If there are 4+ cards promoted, gain 3 money.",
+      "If there are 4+ cards promoted, +3 money.",
       "eot promote a card played this turn"
     ],
     "effectKey": "drow-negotiator",
@@ -381,7 +381,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "spy, troop there for 1 attack"
+      "place spy, then if another player's troop there, +1 attack"
     ],
     "effectKey": "infiltrator",
     "_matchedSheet": true
@@ -398,7 +398,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "spy, troop there for 1 attack"
+      "place spy, then if another player's troop there, +1 attack"
     ],
     "effectKey": "infiltrator",
     "_matchedSheet": true
@@ -415,8 +415,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return spy for 3 cards"
+      "or place spy",
+      "or return spy to draw 3 cards"
     ],
     "effectKey": "information-broker",
     "_matchedSheet": true
@@ -433,8 +433,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return spy for 3 cards"
+      "or place spy",
+      "or return spy to draw 3 cards"
     ],
     "effectKey": "information-broker",
     "_matchedSheet": true
@@ -451,8 +451,8 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or 2 money",
-      "or assassinate"
+      "or +2 money",
+      "or assassinate a troop"
     ],
     "effectKey": "inquisitor",
     "_matchedSheet": true
@@ -506,7 +506,7 @@
     "rarity": 1,
     "benefits": [
       "or place 2 spies",
-      "or return a spy for 4 atk"
+      "or return a spy to +4 attack"
     ],
     "effectKey": "masters-of-sorcere",
     "_matchedSheet": true
@@ -541,8 +541,9 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
+      "choose 3 times:",
       "or deploy a troop",
-      "or assassinate white troop"
+      "or assassinate a white troop"
     ],
     "effectKey": "weaponmaster",
     "_matchedSheet": true
@@ -593,7 +594,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "spy"
+      "place spy"
     ],
     "effectKey": "spy-master",
     "_matchedSheet": true
@@ -610,7 +611,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "spy"
+      "place spy"
     ],
     "effectKey": "spy-master",
     "_matchedSheet": true
@@ -627,7 +628,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return spy to supplant a troop there"
     ],
     "effectKey": "spellspinner",
@@ -645,7 +646,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return spy to supplant a troop there"
     ],
     "effectKey": "spellspinner",
@@ -663,7 +664,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return spy to supplant a troop there"
     ],
     "effectKey": "spellspinner",
@@ -681,7 +682,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "3 troops"
+      "deploy 3 troops"
     ],
     "effectKey": "mercenary-squad",
     "_matchedSheet": true
@@ -698,7 +699,7 @@
     "type": "Drow",
     "rarity": 1,
     "benefits": [
-      "3 troops"
+      "deploy 3 troops"
     ],
     "effectKey": "mercenary-squad",
     "_matchedSheet": true
@@ -733,7 +734,7 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "1 money",
+      "+1 money",
       "assassinate a white troop"
     ],
     "effectKey": "black-wyrmling",
@@ -751,7 +752,7 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "1 money",
+      "+1 money",
       "assassinate a white troop"
     ],
     "effectKey": "black-wyrmling",
@@ -769,7 +770,7 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "eot promote 2 other cards",
+      "eot promote up to 2 other cards",
       "1vp per 3 promoted cards"
     ],
     "effectKey": "blue-dragon",
@@ -787,8 +788,8 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "3 money",
-      "return a troop or spy"
+      "+3 money",
+      "return another player's troop/spy"
     ],
     "effectKey": "blue-wyrmling",
     "_matchedSheet": true
@@ -805,8 +806,8 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "3 money",
-      "return a troop or spy"
+      "+3 money",
+      "return another player's troop/spy"
     ],
     "effectKey": "blue-wyrmling",
     "_matchedSheet": true
@@ -823,7 +824,7 @@
     "type": "Troglodyte",
     "rarity": 1,
     "benefits": [
-      "Move an enemy troop",
+      "move an enemy troop",
       "eot promote a played card"
     ],
     "effectKey": "cleric-of-laogzed",
@@ -841,7 +842,7 @@
     "type": "Troglodyte",
     "rarity": 1,
     "benefits": [
-      "Move an enemy troop",
+      "move an enemy troop",
       "eot promote a played card"
     ],
     "effectKey": "cleric-of-laogzed",
@@ -859,7 +860,7 @@
     "type": "Half-Dragon",
     "rarity": 1,
     "benefits": [
-      "2 money",
+      "+2 money",
       "may devour a market card"
     ],
     "effectKey": "cult-fanatic",
@@ -877,7 +878,7 @@
     "type": "Half-Dragon",
     "rarity": 1,
     "benefits": [
-      "2 money",
+      "+2 money",
       "may devour a market card"
     ],
     "effectKey": "cult-fanatic",
@@ -895,8 +896,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or 2 money"
+      "or +2 attack",
+      "or +2 money"
     ],
     "effectKey": "dragon-cultist",
     "_matchedSheet": true
@@ -913,8 +914,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or 2 money"
+      "or +2 attack",
+      "or +2 money"
     ],
     "effectKey": "dragon-cultist",
     "_matchedSheet": true
@@ -931,8 +932,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or 2 money"
+      "or +2 attack",
+      "or +2 money"
     ],
     "effectKey": "dragon-cultist",
     "_matchedSheet": true
@@ -949,8 +950,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or 2 money"
+      "or +2 attack",
+      "or +2 money"
     ],
     "effectKey": "dragon-cultist",
     "_matchedSheet": true
@@ -967,8 +968,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "assassinate a troop",
-      "5 trophies ? 2 attack"
+      "assassinate a troop, ",
+      "then 5 trophies ? +2 attack"
     ],
     "effectKey": "dragonclaw",
     "_matchedSheet": true
@@ -985,8 +986,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "assassinate a troop",
-      "5 trophies ? 2 attack"
+      "assassinate a troop, ",
+      "then 5 trophies ? +2 attack"
     ],
     "effectKey": "dragonclaw",
     "_matchedSheet": true
@@ -1003,8 +1004,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "spy",
-      "return spy 4 attack"
+      "or place spy",
+      "or return spy to +4 attack"
     ],
     "effectKey": "enchanter-of-thay",
     "_matchedSheet": true
@@ -1021,8 +1022,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "spy",
-      "return spy 4 attack"
+      "or place spy",
+      "or return spy to +4 attack"
     ],
     "effectKey": "enchanter-of-thay",
     "_matchedSheet": true
@@ -1039,8 +1040,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "spy",
-      "return spy 4 attack"
+      "or place spy",
+      "or return spy to +4 attack"
     ],
     "effectKey": "enchanter-of-thay",
     "_matchedSheet": true
@@ -1057,8 +1058,8 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "or spy, supplant troop there",
-      "or return spy, supplant a troop there, 1vp for each site control marker you have"
+      "or place spy, supplant troop there",
+      "or return spy to supplant a troop there, 1vp for each site control marker you have"
     ],
     "effectKey": "green-dragon",
     "_matchedSheet": true
@@ -1075,8 +1076,7 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "place a spy",
-      "if another player's troop there, 2 money"
+      "place spy, then if another player's troop there, +2 money"
     ],
     "effectKey": "green-wyrmling",
     "_matchedSheet": true
@@ -1093,8 +1093,7 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "place a spy",
-      "if another player's troop there, 2 money"
+      "place spy, then if another player's troop there, +2 money"
     ],
     "effectKey": "green-wyrmling",
     "_matchedSheet": true
@@ -1112,7 +1111,7 @@
     "rarity": 1,
     "benefits": [
       "draw 2 cards",
-      "spy"
+      "place spy"
     ],
     "effectKey": "rath-modar",
     "_matchedSheet": true
@@ -1130,7 +1129,8 @@
     "rarity": 1,
     "benefits": [
       "supplant a troop",
-      "return enemy spy, 1vp for each total controlled site"
+      "return enemy spy",
+      "1vp for each total controlled site"
     ],
     "effectKey": "red-dragon",
     "_matchedSheet": true
@@ -1147,7 +1147,7 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "2 atk 2 money"
+      "+2 attack +2 money"
     ],
     "effectKey": "red-wyrmling",
     "_matchedSheet": true
@@ -1164,7 +1164,7 @@
     "type": "Dragon",
     "rarity": 1,
     "benefits": [
-      "2 atk 2 money"
+      "+2 attack +2 money"
     ],
     "effectKey": "red-wyrmling",
     "_matchedSheet": true
@@ -1181,7 +1181,7 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "5 atk"
+      "+5 attack"
     ],
     "effectKey": "severin-silrajin",
     "_matchedSheet": true
@@ -1198,7 +1198,7 @@
     "type": "Dwarf",
     "rarity": 1,
     "benefits": [
-      "1 money",
+      "+1 money",
       "eot promote a played card"
     ],
     "effectKey": "wyrmspeaker",
@@ -1216,7 +1216,7 @@
     "type": "Dwarf",
     "rarity": 1,
     "benefits": [
-      "1 money",
+      "+1 money",
       "eot promote a played card"
     ],
     "effectKey": "wyrmspeaker",
@@ -1234,7 +1234,7 @@
     "type": "Dwarf",
     "rarity": 1,
     "benefits": [
-      "1 money",
+      "+1 money",
       "eot promote a played card"
     ],
     "effectKey": "wyrmspeaker",
@@ -1253,7 +1253,7 @@
     "rarity": 1,
     "benefits": [
       "deploy 2 troops",
-      "may discard a card in market"
+      "may devour a card in market"
     ],
     "effectKey": "white-wyrmling",
     "_matchedSheet": true
@@ -1271,7 +1271,7 @@
     "rarity": 1,
     "benefits": [
       "deploy 2 troops",
-      "may discard a card in market"
+      "may devour a card in market"
     ],
     "effectKey": "white-wyrmling",
     "_matchedSheet": true
@@ -1289,7 +1289,7 @@
     "rarity": 1,
     "benefits": [
       "deploy 2 troops",
-      "may discard a card in market"
+      "may devour a card in market"
     ],
     "effectKey": "white-wyrmling",
     "_matchedSheet": true
@@ -1360,8 +1360,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return spy for 3 money"
+      "or place spy",
+      "or return spy to +3 money"
     ],
     "effectKey": "watcher-of-thay",
     "_matchedSheet": true
@@ -1378,8 +1378,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return spy for 3 money"
+      "or place spy",
+      "or return spy to +3 money"
     ],
     "effectKey": "watcher-of-thay",
     "_matchedSheet": true
@@ -1396,8 +1396,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return spy for 3 money"
+      "or place spy",
+      "or return spy to +3 money"
     ],
     "effectKey": "watcher-of-thay",
     "_matchedSheet": true
@@ -1432,8 +1432,9 @@
     "type": "Elf",
     "rarity": 1,
     "benefits": [
-      "1 attack, spy",
-      "recruite a guile card that costs 4 or less"
+      "+1 attack",
+      "place spy",
+      "recruite a Guile card that costs 4 or less"
     ],
     "effectKey": "aerisi-kalinoth",
     "_matchedSheet": true
@@ -1450,7 +1451,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return a spy to deploy 3 troops",
       "focus: draw a card"
     ],
@@ -1469,7 +1470,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return a spy to deploy 3 troops",
       "focus: draw a card"
     ],
@@ -1488,7 +1489,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return a spy to deploy 3 troops",
       "focus: draw a card"
     ],
@@ -1507,7 +1508,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return a spy to deploy 3 troops",
       "focus: draw a card"
     ],
@@ -1526,7 +1527,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "spy",
+      "place spy",
       "eot promote an Obedience card played this turn"
     ],
     "effectKey": "air-elemental-myrmidon",
@@ -1544,7 +1545,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "spy",
+      "place spy",
       "eot promote an Obedience card played this turn"
     ],
     "effectKey": "air-elemental-myrmidon",
@@ -1563,7 +1564,7 @@
     "rarity": 1,
     "benefits": [
       "eot promote another played card",
-      "focus: 2 money"
+      "focus: +2 money"
     ],
     "effectKey": "black-earth-cultist",
     "_matchedSheet": true
@@ -1581,7 +1582,7 @@
     "rarity": 1,
     "benefits": [
       "eot promote another played card",
-      "focus: 2 money"
+      "focus: +2 money"
     ],
     "effectKey": "black-earth-cultist",
     "_matchedSheet": true
@@ -1599,7 +1600,7 @@
     "rarity": 1,
     "benefits": [
       "eot promote another played card",
-      "focus: 2 money"
+      "focus: +2 money"
     ],
     "effectKey": "black-earth-cultist",
     "_matchedSheet": true
@@ -1617,7 +1618,7 @@
     "rarity": 1,
     "benefits": [
       "eot promote another played card",
-      "focus: 2 money"
+      "focus: +2 money"
     ],
     "effectKey": "black-earth-cultist",
     "_matchedSheet": true
@@ -1688,8 +1689,8 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "1 money",
-      "return another troops/spy",
+      "+1 money",
+      "return another player's troop/spy",
       "focus: draw a card"
     ],
     "effectKey": "earth-elemental",
@@ -1707,8 +1708,8 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "1 money",
-      "return another troops/spy",
+      "+1 money",
+      "return another player's troop/spy",
       "focus: draw a card"
     ],
     "effectKey": "earth-elemental",
@@ -1726,7 +1727,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "2 money",
+      "+2 money",
       "eot promote another played card"
     ],
     "effectKey": "earth-elemental-myrmidon",
@@ -1744,7 +1745,7 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "2 money",
+      "+2 money",
       "eot promote another played card"
     ],
     "effectKey": "earth-elemental-myrmidon",
@@ -1763,7 +1764,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate a troop",
-      "focus: 2 attack"
+      "focus: +2 attack"
     ],
     "effectKey": "eternal-flame-cultist",
     "_matchedSheet": true
@@ -1781,7 +1782,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate a troop",
-      "focus: 2 attack"
+      "focus: +2 attack"
     ],
     "effectKey": "eternal-flame-cultist",
     "_matchedSheet": true
@@ -1799,7 +1800,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate a troop",
-      "focus: 2 attack"
+      "focus: +2 attack"
     ],
     "effectKey": "eternal-flame-cultist",
     "_matchedSheet": true
@@ -1816,8 +1817,8 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or 2 money",
+      "or +2 attack",
+      "or +2 money",
       "focus: draw a card"
     ],
     "effectKey": "fire-elemental",
@@ -1835,8 +1836,8 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or 2 money",
+      "or +2 attack",
+      "or +2 money",
       "focus: draw a card"
     ],
     "effectKey": "fire-elemental",
@@ -1854,8 +1855,8 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "or 2 attack",
-      "or 2 money",
+      "or +2 attack",
+      "or +2 money",
       "focus: draw a card"
     ],
     "effectKey": "fire-elemental",
@@ -1873,8 +1874,8 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "2 attack",
-      "eot promote an obedience card played this turn"
+      "+2 attack",
+      "eot promote an Obedience card played this turn"
     ],
     "effectKey": "fire-elemental-myrmidon",
     "_matchedSheet": true
@@ -1891,8 +1892,8 @@
     "type": "Elemental",
     "rarity": 1,
     "benefits": [
-      "2 attack",
-      "eot promote an obedience card played this turn"
+      "+2 attack",
+      "eot promote an Obedience card played this turn"
     ],
     "effectKey": "fire-elemental-myrmidon",
     "_matchedSheet": true
@@ -1910,7 +1911,7 @@
     "rarity": 1,
     "benefits": [
       "deploy 3 troops",
-      "recruit a conquest card that costs 4 or less"
+      "recruit a Conquest card that costs 4 or less"
     ],
     "effectKey": "gar-shatterkeel",
     "_matchedSheet": true
@@ -1927,9 +1928,9 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return a spy 3 money",
-      "focus: 1 attack"
+      "or place spy",
+      "or return a spy to +3 money",
+      "focus: +1 attack"
     ],
     "effectKey": "howling-hatred-cultist",
     "_matchedSheet": true
@@ -1946,9 +1947,9 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return a spy 3 money",
-      "focus: 1 attack"
+      "or place spy",
+      "or return a spy to +3 money",
+      "focus: +1 attack"
     ],
     "effectKey": "howling-hatred-cultist",
     "_matchedSheet": true
@@ -1965,8 +1966,8 @@
     "type": "Elemental Prince",
     "rarity": 1,
     "benefits": [
-      "4 attack",
-      "focus: 2 attack"
+      "+4 attack",
+      "focus: +2 attack"
     ],
     "effectKey": "imix",
     "_matchedSheet": true
@@ -1983,9 +1984,9 @@
     "type": "Medusa",
     "rarity": 1,
     "benefits": [
-      "1 money",
+      "+1 money",
       "eot promote another played card",
-      "recruit an ambition card that costs 4 or less"
+      "recruit an Ambition card that costs 4 or less"
     ],
     "effectKey": "marlos-urnrayle",
     "_matchedSheet": true
@@ -2002,7 +2003,8 @@
     "type": "Elemental Prince",
     "rarity": 1,
     "benefits": [
-      "2 money, eot promote another played card",
+      "+2 money",
+      "eot promote another played card",
       "focus: eot promote another played card"
     ],
     "effectKey": "ogremoch",
@@ -2039,7 +2041,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate a troop",
-      "recruit a malice card that costs 4 or less"
+      "recruit a Malice card that costs 4 or less"
     ],
     "effectKey": "vanifer",
     "_matchedSheet": true
@@ -2111,7 +2113,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate a white troop",
-      "eot promote an obedience card played this turn"
+      "eot promote an Obedience card played this turn"
     ],
     "effectKey": "water-elemental-myrmidon",
     "_matchedSheet": true
@@ -2129,7 +2131,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate a white troop",
-      "eot promote an obedience card played this turn"
+      "eot promote an Obedience card played this turn"
     ],
     "effectKey": "water-elemental-myrmidon",
     "_matchedSheet": true
@@ -2146,8 +2148,8 @@
     "type": "Elemental Prince",
     "rarity": 1,
     "benefits": [
-      "spy, assassinate a troop there",
-      "focus: spy"
+      "place spy, assassinate a troop there",
+      "focus: place spy"
     ],
     "effectKey": "yan-c-bin",
     "_matchedSheet": true
@@ -2183,7 +2185,7 @@
     "rarity": 1,
     "benefits": [
       "devour a card in hand to supplant 2 white troops,",
-      "each opponent recruits 2 insane outcasts"
+      "then each opponent recruits 2 insane outcasts"
     ],
     "effectKey": "demogorgon",
     "_matchedSheet": true
@@ -2308,7 +2310,7 @@
     "type": "Undead",
     "rarity": 1,
     "benefits": [
-      "2 attack",
+      "+2 attack",
       "give insane outcast to each opponent"
     ],
     "effectKey": "ghoul",
@@ -2326,7 +2328,7 @@
     "type": "Undead",
     "rarity": 1,
     "benefits": [
-      "2 attack",
+      "+2 attack",
       "give insane outcast to each opponent"
     ],
     "effectKey": "ghoul",
@@ -2344,7 +2346,7 @@
     "type": "Undead",
     "rarity": 1,
     "benefits": [
-      "2 attack",
+      "+2 attack",
       "give insane outcast to each opponent"
     ],
     "effectKey": "ghoul",
@@ -2416,8 +2418,7 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "devour a card from hand to",
-      "assassinate 2 troops"
+      "devour a card from hand to assassinate 2 troops"
     ],
     "effectKey": "glabrezu",
     "_matchedSheet": true
@@ -2488,8 +2489,8 @@
     "type": "Shapechanger",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or remove spy for 2 atk 2 money"
+      "or place spy",
+      "or remove spy to +2 attack +2 money"
     ],
     "effectKey": "jackalwere",
     "_matchedSheet": true
@@ -2506,8 +2507,8 @@
     "type": "Shapechanger",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or remove spy for 2 atk 2 money"
+      "or place spy",
+      "or remove spy to +2 attack +2 money"
     ],
     "effectKey": "jackalwere",
     "_matchedSheet": true
@@ -2524,8 +2525,8 @@
     "type": "Shapechanger",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or remove spy for 2 atk 2 money"
+      "or place spy",
+      "or remove spy to +2 attack +2 money"
     ],
     "effectKey": "jackalwere",
     "_matchedSheet": true
@@ -2542,7 +2543,7 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "devour a card in your hand for 5 attack"
+      "devour a card in your hand to +5 attack"
     ],
     "effectKey": "marilith",
     "_matchedSheet": true
@@ -2559,7 +2560,7 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "devour a card in your hand for 5 attack"
+      "devour a card in your hand to +5 attack"
     ],
     "effectKey": "marilith",
     "_matchedSheet": true
@@ -2577,7 +2578,8 @@
     "rarity": 1,
     "benefits": [
       "devour a card from hand to",
-      "3 money or assassinate a troop"
+      "or +3 money",
+      "or assassinate a troop"
     ],
     "effectKey": "mind-flayer",
     "_matchedSheet": true
@@ -2595,7 +2597,8 @@
     "rarity": 1,
     "benefits": [
       "devour a card from hand to",
-      "3 money or assassinate a troop"
+      "or +3 money",
+      "or assassinate a troop"
     ],
     "effectKey": "mind-flayer",
     "_matchedSheet": true
@@ -2613,7 +2616,8 @@
     "rarity": 1,
     "benefits": [
       "devour a card from hand to",
-      "3 money or assassinate a troop"
+      "or +3 money",
+      "or assassinate a troop"
     ],
     "effectKey": "mind-flayer",
     "_matchedSheet": true
@@ -2630,7 +2634,7 @@
     "type": "Myconid",
     "rarity": 1,
     "benefits": [
-      "2 money",
+      "+2 money",
       "give insane outcast"
     ],
     "effectKey": "myconid-adult",
@@ -2648,7 +2652,7 @@
     "type": "Myconid",
     "rarity": 1,
     "benefits": [
-      "2 money",
+      "+2 money",
       "give insane outcast"
     ],
     "effectKey": "myconid-adult",
@@ -2666,7 +2670,7 @@
     "type": "Myconid",
     "rarity": 1,
     "benefits": [
-      "2 money",
+      "+2 money",
       "give insane outcast"
     ],
     "effectKey": "myconid-adult",
@@ -2720,8 +2724,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "3 money",
-      "promote your top card"
+      "+3 money",
+      "promote top card of your deck"
     ],
     "effectKey": "nalfeshnee",
     "_matchedSheet": true
@@ -2738,8 +2742,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "3 money",
-      "promote your top card"
+      "+3 money",
+      "promote top card of your deck"
     ],
     "effectKey": "nalfeshnee",
     "_matchedSheet": true
@@ -2756,8 +2760,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or remove spy for 2 cards"
+      "or place spy",
+      "or remove spy to draw 2 cards"
     ],
     "effectKey": "night-hag",
     "_matchedSheet": true
@@ -2774,8 +2778,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or remove spy for 2 cards"
+      "or place spy",
+      "or remove spy to draw 2 cards"
     ],
     "effectKey": "night-hag",
     "_matchedSheet": true
@@ -2792,8 +2796,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or remove spy for 2 cards"
+      "or place spy",
+      "or remove spy to draw 2 cards"
     ],
     "effectKey": "night-hag",
     "_matchedSheet": true
@@ -2846,8 +2850,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "or spy",
-      "or return a spy for 5 attack"
+      "or place spy",
+      "or return a spy to +5 attack"
     ],
     "effectKey": "vrock",
     "_matchedSheet": true
@@ -2865,7 +2869,7 @@
     "rarity": 1,
     "benefits": [
       "devour a card in your inner circle to",
-      "3 money and eot promote up to 2 other played cards"
+      "+3 money and eot promote up to 2 other played cards"
     ],
     "effectKey": "zuggtmoy",
     "_matchedSheet": true
@@ -2882,8 +2886,8 @@
     "type": "Aberration",
     "rarity": 1,
     "benefits": [
-      "promote your top card",
-      "Play a card from your inner-circle as if it were in your hand (it stays there)"
+      "promote top card of your deck",
+      "play a card from your inner-circle as if it were in your hand (it stays there)"
     ],
     "effectKey": "elder-brain",
     "_matchedSheet": true
@@ -2917,7 +2921,7 @@
     "type": "Illithid",
     "rarity": 2,
     "benefits": [
-      "2 money",
+      "+2 money",
       "eot promote another card played this turn"
     ],
     "effectKey": "puppeteer",
@@ -2935,7 +2939,7 @@
     "type": "Aberration",
     "rarity": 2,
     "benefits": [
-      "or 3 money",
+      "or +3 money",
       "or return up to 2 troops/spies"
     ],
     "effectKey": "intellect-devourer",
@@ -2954,7 +2958,7 @@
     "rarity": 4,
     "benefits": [
       "eot promote another played card",
-      "if you discard this, you may promote it"
+      "if your opponent causes you to discard this, you may promote it"
     ],
     "effectKey": "ambassador",
     "_matchedSheet": true
@@ -2989,8 +2993,8 @@
     "type": "Aberration",
     "rarity": 2,
     "benefits": [
-      "spy",
-      "each opponent there discards a card if they have 3+"
+      "place spy",
+      "each opponent there with 3+ cards discards a card"
     ],
     "effectKey": "chuul",
     "_matchedSheet": true
@@ -3007,8 +3011,8 @@
     "type": "Aberration",
     "rarity": 2,
     "benefits": [
-      "or spy",
-      "or return a spy for 2 attack 2 money"
+      "or place spy",
+      "or return a spy to +2 attack +2 money"
     ],
     "effectKey": "brainwashed-slave",
     "_matchedSheet": true
@@ -3025,8 +3029,8 @@
     "type": "Aberration",
     "rarity": 2,
     "benefits": [
-      "or spy",
-      "or return a spy to draw a card, each 3+ opponent discards a card"
+      "or place spy",
+      "or return a spy to draw a card, each opponent with 3+ cards discards a card"
     ],
     "effectKey": "nothic",
     "_matchedSheet": true
@@ -3043,7 +3047,7 @@
     "type": "Aberration",
     "rarity": 3,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return spy to assassinate a troop there"
     ],
     "effectKey": "cloaker",
@@ -3114,8 +3118,8 @@
     "type": "Aberration",
     "rarity": 1,
     "benefits": [
-      "Assassinate up to 3 troops at a single site.",
-      "For each troop removed gain 1 money."
+      "assassinate up to 3 troops at a single site.",
+      "for each troop removed +1 money."
     ],
     "effectKey": "death-tyrant",
     "_matchedSheet": true
@@ -3133,7 +3137,7 @@
     "rarity": 3,
     "benefits": [
       "deploy 2 troops",
-      "Choose an opponent with 3+ cards to discard a card."
+      "choose an opponent with 3+ cards to discard a card."
     ],
     "effectKey": "cranium-rats",
     "_matchedSheet": true
@@ -3151,7 +3155,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate a troop",
-      "gain 1 attack for every 3 troops in your trophy hall"
+      "+1 attack for every 3 troops in your trophy hall"
     ],
     "effectKey": "beholder",
     "_matchedSheet": true
@@ -3186,7 +3190,7 @@
     "type": "Aberration",
     "rarity": 2,
     "benefits": [
-      "or 2 money",
+      "or +2 money",
       "or draw a card, choose an opponent with 3+ cards to discard a card"
     ],
     "effectKey": "gauth",
@@ -3204,7 +3208,7 @@
     "type": "Aberration",
     "rarity": 3,
     "benefits": [
-      "2 attack 1 money"
+      "+2 attack +1 money"
     ],
     "effectKey": "spectator",
     "_matchedSheet": true
@@ -3239,7 +3243,7 @@
     "type": "Undead",
     "rarity": 2,
     "benefits": [
-      "spy",
+      "place spy",
       "if there is another spy there, +3 attack"
     ],
     "effectKey": "banshee",
@@ -3257,7 +3261,7 @@
     "type": "Undead",
     "rarity": 3,
     "benefits": [
-      "1 money",
+      "+1 money",
       "return another player's troop/spy"
     ],
     "effectKey": "vampire-spawn",
@@ -3276,7 +3280,7 @@
     "rarity": 1,
     "benefits": [
       "supplant a troop",
-      "gain 1 VP for every 5 player trophies you have"
+      "1 VP for every 5 player trophies you have"
     ],
     "effectKey": "death-knight",
     "_matchedSheet": true
@@ -3293,7 +3297,7 @@
     "type": "Human",
     "rarity": 3,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return a spy to recruit up to 2 cards that cost 3 or less"
     ],
     "effectKey": "conjurer",
@@ -3311,7 +3315,7 @@
     "type": "Undead",
     "rarity": 2,
     "benefits": [
-      "or spy",
+      "or place spy",
       "or return a spy to treat the top devoured card as if in market"
     ],
     "effectKey": "ghost",
@@ -3329,7 +3333,7 @@
     "type": "Undead",
     "rarity": 4,
     "benefits": [
-      "or 2 attack",
+      "or +2 attack",
       "or devour a card from hand to supplant a troop"
     ],
     "effectKey": "wight",
@@ -3347,9 +3351,9 @@
     "type": "Undead",
     "rarity": 1,
     "benefits": [
-      "choose twice:",
-      "assassinate a white troop",
-      "take a white trophy from another player and place it anwhere"
+      "choose 2 times",
+      "or assassinate a white troop",
+      "or take a white trophy from any player and place it anwhere"
     ],
     "effectKey": "mummy-lord",
     "_matchedSheet": true
@@ -3366,7 +3370,7 @@
     "type": "Undead",
     "rarity": 2,
     "benefits": [
-      "1 attack",
+      "+1 attack",
       "assassinate a white troop"
     ],
     "effectKey": "ravenous-zombies",
@@ -3384,8 +3388,8 @@
     "type": "Human",
     "rarity": 3,
     "benefits": [
-      "or 2 money",
-      "or devour this card to EOT promote up to 2 other cards played"
+      "or +2 money",
+      "or devour this card to eot promote up to 2 other cards played"
     ],
     "effectKey": "cultist-of-myrkul",
     "_matchedSheet": true
@@ -3438,7 +3442,7 @@
     "type": "Undead",
     "rarity": 2,
     "benefits": [
-      "spy",
+      "place spy",
       "devour this card to assassinate a troop there"
     ],
     "effectKey": "wraith",
@@ -3473,7 +3477,7 @@
     "type": "Undead",
     "rarity": 1,
     "benefits": [
-      "spy",
+      "place spy",
       "if another player has a troop there, take 2 troops from their trophy hall and deploy them"
     ],
     "effectKey": "lich",
@@ -3491,8 +3495,8 @@
     "type": "Human",
     "rarity": 1,
     "benefits": [
-      "return another player's troop or spy",
-      "EOT promote any undead cards you played"
+      "return another player's troop/spy",
+      "eot promote any undead cards you played (optional)"
     ],
     "effectKey": "high-priest-of-myrkul",
     "_matchedSheet": true
@@ -3509,7 +3513,7 @@
     "type": "Human",
     "rarity": 2,
     "benefits": [
-      "or 3 money",
+      "or +3 money",
       "or promote this card, or from hand, or from discard"
     ],
     "effectKey": "necromancer",
@@ -3545,7 +3549,7 @@
     "type": "Construct",
     "rarity": 2,
     "benefits": [
-      "2 attack",
+      "+2 attack",
       "devour this card to assassinate a troop"
     ],
     "effectKey": "flesh-golem",
@@ -3563,7 +3567,7 @@
     "type": "Monstrosity",
     "rarity": 2,
     "benefits": [
-      "3 attack",
+      "+3 attack",
       "devour a card in the market and replace it with this one"
     ],
     "effectKey": "carrion-crawler",
@@ -3582,7 +3586,7 @@
     "rarity": 1,
     "benefits": [
       "assassinate two troops,",
-      "If you have 8+ trophies, promote this card"
+      "if you have 8+ trophies, promote this card"
     ],
     "effectKey": "revenant",
     "_matchedSheet": true
@@ -3599,7 +3603,7 @@
     "type": "Drow",
     "rarity": 15,
     "benefits": [
-      "2 attack"
+      "+2 attack"
     ],
     "effectKey": "house-guard",
     "_matchedSheet": true
@@ -3616,8 +3620,8 @@
     "type": "Drow",
     "rarity": 30,
     "benefits": [
-      "discard a card from your hand to return this card to the supply.",
-      "If this card would be devoured or promoted, return it to the supply"
+      "discard a card from your hand to return this card to the supply",
+      "if this card would be devoured or promoted, return it to the supply"
     ],
     "effectKey": "insane-outcast",
     "_matchedSheet": true
@@ -3634,7 +3638,7 @@
     "type": "Drow",
     "rarity": 15,
     "benefits": [
-      "2 money"
+      "+2 money"
     ],
     "effectKey": "priestess-of-lolth",
     "_matchedSheet": true
@@ -3651,7 +3655,7 @@
     "type": "Drow",
     "rarity": 7,
     "benefits": [
-      "money"
+      "+1 money"
     ],
     "effectKey": "noble",
     "_matchedSheet": true
@@ -3668,7 +3672,7 @@
     "type": "Drow",
     "rarity": 3,
     "benefits": [
-      "attack"
+      "+1 attack"
     ],
     "effectKey": "soldier",
     "_matchedSheet": true
@@ -3685,7 +3689,7 @@
     "type": "Drow",
     "rarity": 7,
     "benefits": [
-      "money"
+      "+1 money"
     ],
     "effectKey": "noble",
     "_matchedSheet": true
@@ -3702,7 +3706,7 @@
     "type": "Drow",
     "rarity": 3,
     "benefits": [
-      "attack"
+      "+1 attack"
     ],
     "effectKey": "soldier",
     "_matchedSheet": true
@@ -3719,7 +3723,7 @@
     "type": "Drow",
     "rarity": 7,
     "benefits": [
-      "money"
+      "+1 money"
     ],
     "effectKey": "noble",
     "_matchedSheet": true
@@ -3736,7 +3740,7 @@
     "type": "Drow",
     "rarity": 3,
     "benefits": [
-      "attack"
+      "+1 attack"
     ],
     "effectKey": "soldier",
     "_matchedSheet": true
@@ -3753,7 +3757,7 @@
     "type": "Drow",
     "rarity": 7,
     "benefits": [
-      "money"
+      "+1 money"
     ],
     "effectKey": "noble",
     "_matchedSheet": true
@@ -3770,7 +3774,7 @@
     "type": "Drow",
     "rarity": 3,
     "benefits": [
-      "attack"
+      "+1 attack"
     ],
     "effectKey": "soldier",
     "_matchedSheet": true

--- a/assets/card-data.json
+++ b/assets/card-data.json
@@ -1076,7 +1076,7 @@
     "rarity": 1,
     "benefits": [
       "place a spy",
-      "it troop there, 2 money"
+      "if another player's troop there, 2 money"
     ],
     "effectKey": "green-wyrmling",
     "_matchedSheet": true
@@ -1094,7 +1094,7 @@
     "rarity": 1,
     "benefits": [
       "place a spy",
-      "it troop there, 2 money"
+      "if another player's troop there, 2 money"
     ],
     "effectKey": "green-wyrmling",
     "_matchedSheet": true

--- a/assets/card-data.json
+++ b/assets/card-data.json
@@ -2180,8 +2180,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "devour a card in hand to supplant a white troop anywhere on the board",
-      "supplant 2 white troops, each opponent recruits 2 insane outcasts"
+      "devour a card in hand to supplant 2 white troops,",
+      "each opponent recruits 2 insane outcasts"
     ],
     "effectKey": "demogorgon",
     "_matchedSheet": true
@@ -2198,8 +2198,8 @@
     "type": "Fiend",
     "rarity": 1,
     "benefits": [
-      "devour a card in your hand for 5 attack",
-      "assassinate 2 troops, take 2 trophies from another hand and deploy them anywhere."
+      "devour a card in your hand to assassinate 2 troops,",
+      "then take 2 trophies from any trophy hall and deploy them anywhere."
     ],
     "effectKey": "orcus",
     "_matchedSheet": true
@@ -2361,7 +2361,7 @@
     "rarity": 1,
     "benefits": [
       "deploy 2 troops",
-      "give insane outcase t player troop adjacent to deployed troop"
+      "give insane outcase to player troop adjacent to deployed troop"
     ],
     "effectKey": "gibbering-mouther",
     "_matchedSheet": true
@@ -2379,7 +2379,7 @@
     "rarity": 1,
     "benefits": [
       "deploy 2 troops",
-      "give insane outcase t player troop adjacent to deployed troop"
+      "give insane outcase to player troop adjacent to deployed troop"
     ],
     "effectKey": "gibbering-mouther",
     "_matchedSheet": true
@@ -2397,7 +2397,7 @@
     "rarity": 1,
     "benefits": [
       "deploy 2 troops",
-      "give insane outcase t player troop adjacent to deployed troop"
+      "give insane outcase to player troop adjacent to deployed troop"
     ],
     "effectKey": "gibbering-mouther",
     "_matchedSheet": true

--- a/assets/card-name-map.json
+++ b/assets/card-name-map.json
@@ -200,3 +200,9 @@
   "undead::37": "Carrion Crawler",
   "undead::38": "Revenant"
 }
+
+{
+  "demons::10": "Demogorgon",
+  "demons::11": "Demogorgon",
+  "demons::12": "Demogorgon"
+}

--- a/assets/card-name-map.json
+++ b/assets/card-name-map.json
@@ -200,9 +200,3 @@
   "undead::37": "Carrion Crawler",
   "undead::38": "Revenant"
 }
-
-{
-  "demons::10": "Demogorgon",
-  "demons::11": "Demogorgon",
-  "demons::12": "Demogorgon"
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2003,10 +2003,12 @@ export function Board({ G, ctx, moves }: BoardProps<TyrantsState>) {
             // If options provided, only those indices are pickable (e.g. Focus reveal filtered to one aspect).
             const opts = isChoosing ? (G.pendingChoice!.options as number[] | undefined) : undefined;
             const eligible = !isChoosing || !opts || opts.includes(i);
+            // Hide ineligible cards entirely when options restrict which cards are pickable
+            if (isChoosing && opts && !eligible) return null;
             const onClick = isChoosing
-              ? (eligible ? () => moves.resolveChoice(i) : undefined)
+              ? () => moves.resolveChoice(i)
               : (myTurn && !G.pendingChoice ? () => playCardSafe(i) : undefined);
-            const label = isChoosing ? (eligible ? 'pick' : '—') : 'play';
+            const label = isChoosing ? 'pick' : 'play';
             return <Card key={i} card={c} label={label} onClick={onClick} />;
           })}
         </div>
@@ -2496,10 +2498,12 @@ function SplitPlayView(props: {
                 const isChoosing = G.pendingChoice?.kind === 'select-card-in-hand' && G.pendingChoice.playerId === me;
                 const opts = isChoosing ? (G.pendingChoice!.options as number[] | undefined) : undefined;
                 const eligible = !isChoosing || !opts || opts.includes(i);
+                // Hide ineligible cards entirely when options restrict which cards are pickable
+                if (isChoosing && opts && !eligible) return null;
                 const onClick = isChoosing
-                  ? (eligible ? () => moves.resolveChoice(i) : undefined)
+                  ? () => moves.resolveChoice(i)
                   : (myTurn && !G.pendingChoice ? () => playCardSafe(i) : undefined);
-                const label = isChoosing ? (eligible ? 'pick' : '—') : 'play';
+                const label = isChoosing ? 'pick' : 'play';
                 return <Card key={i} card={c} label={label} onClick={onClick} />;
               })}
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -761,13 +761,21 @@ export function Board({ G, ctx, moves }: BoardProps<TyrantsState>) {
       const wrapped = { ...template, G, ctx } as { G: TyrantsState; ctx: typeof ctx };
       const next = reducer(wrapped, action('playCard', [i], me)) as { G: TyrantsState };
       if (next === wrapped) continue;        // invalid (shouldn't happen on your turn)
-      // Skip a card that would FIZZLE — e.g. Mind Flayer / Marilith played as
+      // 1. Skip a card that would FIZZLE — e.g. Mind Flayer / Marilith played as
       // your last card, where "devour a card from hand" has no food left. It
       // opens no prompt, so the naive check below would treat it as a free
       // basic and auto-play it for zero effect (#74). Leave it for the player.
       if ((next.G as unknown as { _playFizzledNoFood?: boolean })._playFizzledNoFood) continue;
-      if (!next.G.pendingChoice) return i;   // non-interactive → "basic"
-    }
+      // NEW FIX CONDITIONS:
+      // 2. Skip cards that created an immediate prompt
+      if (next.G.pendingChoice) continue;
+      // 3. Skip cards that queued up an End-of-Turn promote trigger
+      const currentEotCount = G.pendingEotPromotions?.length ?? 0;
+      const nextEotCount = next.G.pendingEotPromotions?.length ?? 0;
+      if (nextEotCount > currentEotCount) continue;
+
+      return i; // Safely confirmed as a non-interactive basic card
+      }
     return null;
   }, [isOnline, aiLookahead, myTurn, G, ctx, me]);
 

--- a/src/components/CardTextVerify.tsx
+++ b/src/components/CardTextVerify.tsx
@@ -23,7 +23,7 @@ function CachedCardImg({ path, alt, style }: { path: string; alt: string; style:
 
 const STORAGE_KEY = 'totu.card-text-overrides';
 type Overrides = Record<string, string>;
-const IN_SCOPE = new Set(['drow', 'dragons', 'elemental', 'demons', 'house-guards', 'priestesses']);
+const IN_SCOPE = new Set(['drow', 'dragons', 'elemental', 'demons', 'aberrations', 'undead', 'house-guards', 'priestesses']);
 
 function load(): Overrides {
   try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }

--- a/src/engine/handler-helpers.ts
+++ b/src/engine/handler-helpers.ts
@@ -1133,6 +1133,7 @@ export function recruitFromMarketFiltered(opts: {
   maxCost: number;
   includeAuxStacks?: boolean;
   quantity?: number;
+  optional?: boolean;
 }): EffectHandler {
   const count = opts.quantity ?? 1;
   return ctx => {
@@ -1199,7 +1200,7 @@ export function recruitFromMarketFiltered(opts: {
       kind: 'select-market-card',
       prompt: `Recruit a ${label} costing ≤${opts.maxCost} (free). ${quantityTag}`,
       options: eligible,
-      optional: true,
+      optional: opts?.optional,
     } as PendingChoice;
     ctx.paused = true;
     ctx.handlerState = state;

--- a/src/engine/handler-helpers.ts
+++ b/src/engine/handler-helpers.ts
@@ -869,9 +869,22 @@ export function playerHasOwnSpy(G: import('../game').TyrantsState, actorId: stri
   return false;
 }
 
-export function playerHasOwnTroopOnBoard(G: import('../game').TyrantsState, actorId: string): boolean {
+export function playerHasOwnTroopOnBoard(G: import('../game').TyrantsState, actorId: string, opts?: {returnFailsafe?: boolean}): boolean {
   const color = G.players[actorId].color;
-  for (const t of Object.values(G.troops)) if (t === color) return true;
+  // This is a failsafe to avoid a player removing their only troop
+  const returnFailsafeOn = opts?.returnFailsafe ?? false;
+  if (returnFailsafeOn) {
+    let count = 0;
+    for (const t of Object.values(G.troops)) {
+      if (t === color) {
+        count++;
+        // Optional optimization: exit early as soon as we find at least 2
+        if (count >= 2) return true;
+      }
+    }
+  } else {
+    for (const t of Object.values(G.troops)) if (t === color) return true;
+  }
   return false;
 }
 
@@ -1119,62 +1132,78 @@ export function recruitFromMarketFiltered(opts: {
   aspect?: string;
   maxCost: number;
   includeAuxStacks?: boolean;
+  quantity?: number;
 }): EffectHandler {
+  const count = opts.quantity ?? 1;
   return ctx => {
-    if (!ctx.pendingChoice) {
-      const eligible: number[] = [];
-      for (let i = 0; i < ctx.G.market.row.length; i++) {
-        const c = ctx.G.market.row[i];
-        if (!c) continue;
-        const data = lookupCard(c.deck, c.slot);
-        if (!data) continue;
-        if (opts.aspect && data.aspect.toLowerCase() !== opts.aspect.toLowerCase()) continue;
-        if (data.cost > opts.maxCost) continue;
-        eligible.push(i);
-      }
-      if (opts.includeAuxStacks) {
-        // House Guard: cost 3, drow/Obedience. Priestess of Lolth: cost 5,
-        // drow/Obedience. Aspect filter applies; both are Obedience.
+    let state = (ctx.handlerState as { remaining: number } | null) ?? { remaining: count };
+
+    // 1. Process the prior response, if any.
+    if (ctx.pendingChoice) {
+      const idx = ctx.pendingChoice.response as number | null;
+      ctx.pendingChoice = null;
+      ctx.paused = false;
+      if (idx == null) { ctx.handlerState = null; return true; } // declined mid-sequence
+      if (idx === -1) {
         const HG = lookupCard('house-guards', 40);
+        if (HG) Mechanics.recruitFromAuxStack(ctx.G, ctx.actorId, 'houseGuards',
+          { deck: HG.deck, slot: HG.slot, name: HG.name, image: HG.image });
+      } else if (idx === -2) {
         const PR = lookupCard('priestesses', 43);
-        if (HG && ctx.G.auxStacks.houseGuards > 0
-          && HG.cost <= opts.maxCost
-          && (!opts.aspect || HG.aspect.toLowerCase() === opts.aspect.toLowerCase())) {
-          eligible.push(-1);
-        }
-        if (PR && ctx.G.auxStacks.priestesses > 0
-          && PR.cost <= opts.maxCost
-          && (!opts.aspect || PR.aspect.toLowerCase() === opts.aspect.toLowerCase())) {
-          eligible.push(-2);
-        }
+        if (PR) Mechanics.recruitFromAuxStack(ctx.G, ctx.actorId, 'priestesses',
+          { deck: PR.deck, slot: PR.slot, name: PR.name, image: PR.image });
+      } else {
+        Mechanics.recruitFromMarket(ctx.G, ctx.actorId, idx);
       }
-      if (eligible.length === 0) return true;
-      const label = opts.aspect ? `${opts.aspect} card` : 'card';
-      ctx.pendingChoice = {
-        kind: 'select-market-card',
-        prompt: `Recruit a ${label} costing ≤${opts.maxCost} (free).`,
-        options: eligible,
-        optional: true,
-      } as PendingChoice;
-      ctx.paused = true;
-      return false;
+      state = { remaining: state.remaining - 1 };
     }
-    const idx = ctx.pendingChoice.response as number | null;
-    ctx.pendingChoice = null;
-    ctx.paused = false;
-    if (idx == null) return true;
-    if (idx === -1) {
+
+    // 2. Set up next prompt or finish.
+    if (state.remaining <= 0) { ctx.handlerState = null; return true; }
+    const eligible: number[] = [];
+    for (let i = 0; i < ctx.G.market.row.length; i++) {
+      const c = ctx.G.market.row[i];
+      if (!c) continue;
+      const data = lookupCard(c.deck, c.slot);
+      if (!data) continue;
+      if (opts.aspect && data.aspect.toLowerCase() !== opts.aspect.toLowerCase()) continue;
+      if (data.cost > opts.maxCost) continue;
+      eligible.push(i);
+    }
+    if (opts.includeAuxStacks) {
+      // House Guard: cost 3, drow/Obedience. Priestess of Lolth: cost 5,
+      // drow/Obedience. Aspect filter applies; both are Obedience.
       const HG = lookupCard('house-guards', 40);
-      if (HG) Mechanics.recruitFromAuxStack(ctx.G, ctx.actorId, 'houseGuards',
-        { deck: HG.deck, slot: HG.slot, name: HG.name, image: HG.image });
-    } else if (idx === -2) {
       const PR = lookupCard('priestesses', 43);
-      if (PR) Mechanics.recruitFromAuxStack(ctx.G, ctx.actorId, 'priestesses',
-        { deck: PR.deck, slot: PR.slot, name: PR.name, image: PR.image });
-    } else {
-      Mechanics.recruitFromMarket(ctx.G, ctx.actorId, idx);
+      if (HG && ctx.G.auxStacks.houseGuards > 0
+        && HG.cost <= opts.maxCost
+        && (!opts.aspect || HG.aspect.toLowerCase() === opts.aspect.toLowerCase())) {
+        eligible.push(-1);
+      }
+      if (PR && ctx.G.auxStacks.priestesses > 0
+        && PR.cost <= opts.maxCost
+        && (!opts.aspect || PR.aspect.toLowerCase() === opts.aspect.toLowerCase())) {
+        eligible.push(-2);
+      }
     }
-    return true;
+    if (eligible.length === 0) {
+      if (state.remaining < count) {
+        Mechanics.log(ctx.G, `(recruit: market layout changed or lacks eligible targets — remaining picks skipped)`);
+      }
+      ctx.handlerState = null;
+      return true;
+    }
+    const label = opts.aspect ? `${opts.aspect} card` : 'card';
+    const quantityTag = count > 1 ? ` (${state.remaining} left)` : '';
+    ctx.pendingChoice = {
+      kind: 'select-market-card',
+      prompt: `Recruit a ${label} costing ≤${opts.maxCost} (free). ${quantityTag}`,
+      options: eligible,
+      optional: true,
+    } as PendingChoice;
+    ctx.paused = true;
+    ctx.handlerState = state;
+    return false;
   };
 }
 

--- a/src/engine/handler-helpers.ts
+++ b/src/engine/handler-helpers.ts
@@ -32,7 +32,7 @@ export function grant(opts: { power?: number; influence?: number; draw?: number 
 // played-card list lives on the per-turn promotion queue.
 
 export function flagEotPromote(
-  opts?: { count?: number; aspectFilter?: string; optional?: boolean },
+  opts?: { count?: number; aspectFilter?: string; typeFilter?: string; optional?: boolean },
 ): EffectHandler {
   return ctx => {
     const n = opts?.count ?? 1;
@@ -51,11 +51,18 @@ export function flagEotPromote(
     // "you may promote..." opt out with `optional: true`. The flag is
     // carried on the trigger so game.ts's endTurn prompt can use it.
     const trigger: import('../game').EotPromoteTrigger = { ...ctx.card };
-    if (opts?.aspectFilter) trigger.aspectFilter = opts.aspectFilter;
+    let tag = ' another card';
+    if (opts?.aspectFilter) {
+      trigger.aspectFilter = opts.aspectFilter;
+      tag = ` ${opts.aspectFilter} card`;
+    }
+    if (opts?.typeFilter) {
+      trigger.typeFilter = opts.typeFilter;
+      tag = ` ${opts.typeFilter} cards`
+    }
     if (opts?.optional) trigger.optional = true;
-    for (let i = 0; i < n; i++) ctx.G.pendingEotPromotions.push(trigger);
-    const tag = opts?.aspectFilter ? ` ${opts.aspectFilter} card` : ' another card';
-    Mechanics.log(ctx.G, `(eot: queued ${n} promote —${tag} played this turn${opts?.optional ? ', optional' : ''})`);
+    for (let i = 0; i < n; i++) ctx.G.pendingEotPromotions.push(trigger); 
+    Mechanics.log(ctx.G, `(eot: queued ${opts?.typeFilter ? '' : n} promote —${tag} played this turn${opts?.optional ? ', optional' : ''})`);
     return true;
   };
 }
@@ -423,7 +430,7 @@ export function returnOwnSpyChoice(opts?: { optional?: boolean }): EffectHandler
         kind: 'select-site',
         prompt: 'Return one of your spies from which site?',
         options: eligible,
-        optional: opts?.optional,
+        optional: opts?.optional ?? true,
       } as PendingChoice;
       ctx.paused = true;
       return false;
@@ -1531,18 +1538,53 @@ export function returnEnemySpyChoice(): EffectHandler {
 
 /** "Return an enemy troop or spy" — Blue Wyrmling's secondary effect.
  *  Pass `{ includeWhite: true }` to also let the player return white
- *  (Underdark) troops — used by Intellect Devourer. */
-export function returnEnemyTroopOrSpyChoice(opts?: { includeWhite?: boolean }): EffectHandler {
+ *  (Underdark) troops — used by Intellect Devourer.
+ *  Pass `{ fizzleIfNoTargets: true }` to set _playFizzledNoFood when
+ *  no enemy troops or spies are returnable, preventing "play all basic"
+ *  from auto-playing the card for zero effect (e.g. High Priest of Myrkul). */
+export function returnEnemyTroopOrSpyChoice(opts?: { includeWhite?: boolean; fizzleIfNoTargets?: boolean }): EffectHandler {
   const includeWhite = !!opts?.includeWhite;
-  return chooseOne(
-    {
-      label: includeWhite ? 'Return a troop (white or enemy)' : 'Return an enemy troop',
-      handler: returnEnemyTroopChoice({ includeWhite }),
-      available: includeWhite ? playerCanReturnAnyTroop : playerCanReturnEnemyTroop,
-    },
-    { label: 'Return an enemy spy', handler: returnEnemySpyChoice(), available: playerCanReturnEnemySpy },
-  );
+  const fizzleIfNoTargets = !!opts?.fizzleIfNoTargets;
+  return ctx => {
+    // When fizzleIfNoTargets is set, check upfront whether either option has
+    // any valid targets. If not, mark the fizzle flag so the "Play all basic"
+    // classifier skips this card — exactly as devourFromHandCost does when
+    // the hand is empty.
+    if (fizzleIfNoTargets && !ctx.pendingChoice && !ctx.handlerState) {
+      const troopAvailable = includeWhite
+        ? playerCanReturnAnyTroop(ctx.G, ctx.actorId)
+        : playerCanReturnEnemyTroop(ctx.G, ctx.actorId);
+      const spyAvailable = playerCanReturnEnemySpy(ctx.G, ctx.actorId);
+      if (!troopAvailable && !spyAvailable) {
+        (ctx.G as unknown as { _playFizzledNoFood?: boolean })._playFizzledNoFood = true;
+        ctx.handlerState = null;
+        Mechanics.log(ctx.G, '(return enemy troop or spy: no valid targets availiable — skipped)');
+        return true;
+      }
+    }
+    return chooseOne(
+      {
+        label: includeWhite ? 'Return a troop (white or enemy)' : 'Return an enemy troop',
+        handler: returnEnemyTroopChoice({ includeWhite }),
+        available: includeWhite ? playerCanReturnAnyTroop : playerCanReturnEnemyTroop,
+      },
+      { label: 'Return an enemy spy', handler: returnEnemySpyChoice(), available: playerCanReturnEnemySpy },
+    )(ctx);
+  };
 }
+// ! Depreciated method below:
+// export function returnEnemyTroopOrSpyChoice(opts?: { includeWhite?: boolean }): EffectHandler {
+//   const includeWhite = !!opts?.includeWhite;
+//   return chooseOne(
+//     {
+//       label: includeWhite ? 'Return a troop (white or enemy)' : 'Return an enemy troop',
+//       handler: returnEnemyTroopChoice({ includeWhite }),
+//       available: includeWhite ? playerCanReturnAnyTroop : playerCanReturnEnemyTroop,
+//     },
+//     { label: 'Return an enemy spy', handler: returnEnemySpyChoice(), available: playerCanReturnEnemySpy },
+//   );
+// }
+
 
 /** True when the player has at least one enemy player-color troop they could
  *  legally return — i.e. a troop in a space where they have presence. */
@@ -1976,7 +2018,7 @@ interface OrcusIterState {
  *  used by Lich ("take 2 trophies from THEIR hall" where "they" is the
  *  opponent with a troop at the spy site). When omitted, any player's
  *  hall is eligible (Orcus's behavior). */
-export function takeTrophyAndPlace(opts: { count: number; ownerPid?: string; whiteOnly?: boolean; restrictToPresence?: boolean }): EffectHandler {
+export function takeTrophyAndPlace(opts: { count: number; ownerPid?: string; whiteOnly?: boolean; restrictToPresence?: boolean; optional?: boolean }): EffectHandler {
   return ctx => {
     let state = (ctx.handlerState as OrcusIterState | null) ?? { remaining: opts.count };
 
@@ -2030,7 +2072,7 @@ export function takeTrophyAndPlace(opts: { count: number; ownerPid?: string; whi
         kind: 'select-troop-space',
         prompt: `Place the ${sel.color} trophy on an empty space${opts.restrictToPresence ? ' where you have presence' : ''} (or decline to skip).`,
         options: eligible,
-        optional: true,
+        optional: opts?.optional ?? true,
       } as PendingChoice;
       ctx.paused = true;
       ctx.handlerState = state;
@@ -2049,7 +2091,7 @@ export function takeTrophyAndPlace(opts: { count: number; ownerPid?: string; whi
       kind: 'choose-one',
       prompt: `Take a trophy${targetTag} (${state.remaining} remaining). Pick which trophy + color:`,
       options: choices.map(c => c.label),
-      optional: true,
+      optional: opts?.optional ?? true,
     } as PendingChoice;
     ctx.paused = true;
     ctx.handlerState = { remaining: state.remaining, picked: undefined };
@@ -2511,7 +2553,7 @@ export function promoteFromHandChoice(opts?: { optional?: boolean }): EffectHand
         kind: 'select-card-in-hand',
         prompt: 'Promote a card from your hand (it moves to your inner circle)',
         options: me.hand.map((_, i) => i),
-        optional: opts?.optional ?? true,
+        optional: opts?.optional,
       } as PendingChoice;
       ctx.paused = true;
       return false;

--- a/src/engine/handler-helpers.ts
+++ b/src/engine/handler-helpers.ts
@@ -294,12 +294,12 @@ export function assassinateAtLastPlacedSpySite(): EffectHandler {
         ctx.handlerState = null;
         return true;
       }
-      Mechanics.log(ctx.G, `(assassinate at ${siteId}: choose a troop or dismiss to skip — ${eligible.length} eligible)`);
+      Mechanics.log(ctx.G, `(assassinate at ${siteId}: choose a troop — ${eligible.length} eligible)`);
       ctx.pendingChoice = {
         kind: 'select-troop-space',
         prompt: `Assassinate a troop at ${siteId}.`,
         options: eligible,
-        optional: true,
+        optional: false,
       } as PendingChoice;
       ctx.paused = true;
       ctx.handlerState = { siteId };
@@ -522,7 +522,7 @@ export function supplantAtLastReturnedSpySite(): EffectHandler {
         kind: 'select-troop-space',
         prompt: `Supplant a troop at ${siteId}.`,
         options: eligible,
-        optional: true,
+        optional: false,
       } as PendingChoice;
       ctx.paused = true;
       return false;
@@ -588,7 +588,7 @@ function legalDeployTargets(
 }
 
 /** Assassinate `count` enemy troops the player has presence at. Trophy hall is auto-updated. */
-export function assassinateChoice(opts?: { count?: number; whiteOnly?: boolean; sameSite?: boolean }): EffectHandler {
+export function assassinateChoice(opts?: { count?: number; whiteOnly?: boolean; sameSite?: boolean; optional?: boolean }): EffectHandler {
   const count = opts?.count ?? 1;
   // The "site key" of a troop space is the segment before the colon — the
   // parentSite for site spaces, the parentRoute for route spaces (see
@@ -633,7 +633,7 @@ export function assassinateChoice(opts?: { count?: number; whiteOnly?: boolean; 
       kind: 'select-troop-space',
       prompt: opts?.whiteOnly ? `Assassinate a white troop (${state.remaining} left).` : `Assassinate an enemy troop (${state.remaining} left).`,
       options: eligible,
-      optional: true,
+      optional: opts?.optional,
     } as PendingChoice;
     ctx.paused = true;
     ctx.handlerState = state;
@@ -642,7 +642,7 @@ export function assassinateChoice(opts?: { count?: number; whiteOnly?: boolean; 
 }
 
 /** Deploy `count` of the player's own troops. `anywhere` waives presence checks. */
-export function deployChoice(opts?: { count?: number; anywhere?: boolean; costless?: boolean }): EffectHandler {
+export function deployChoice(opts?: { count?: number; anywhere?: boolean; costless?: boolean; optional?: boolean}): EffectHandler {
   const count = opts?.count ?? 1;
   return ctx => {
     let state = (ctx.handlerState as { remaining: number } | null) ?? { remaining: count };
@@ -687,7 +687,7 @@ export function deployChoice(opts?: { count?: number; anywhere?: boolean; costle
       kind: 'select-troop-space',
       prompt: `Deploy a troop (${state.remaining} left).${opts?.anywhere ? ' Anywhere on the board.' : ''}`,
       options: eligible,
-      optional: true,
+      optional: opts?.optional,
     } as PendingChoice;
     ctx.paused = true;
     ctx.handlerState = state;
@@ -696,7 +696,7 @@ export function deployChoice(opts?: { count?: number; anywhere?: boolean; costle
 }
 
 /** Supplant: assassinate a target and then deploy in the same space. */
-export function supplantChoice(opts?: { whiteOnly?: boolean; anywhere?: boolean }): EffectHandler {
+export function supplantChoice(opts?: { whiteOnly?: boolean; anywhere?: boolean; optional?: boolean }): EffectHandler {
   return ctx => {
     const state = (ctx.handlerState as { picked?: string } | null) ?? {};
     if (!ctx.pendingChoice && !state.picked) {
@@ -720,7 +720,7 @@ export function supplantChoice(opts?: { whiteOnly?: boolean; anywhere?: boolean 
         kind: 'select-troop-space',
         prompt: opts?.whiteOnly ? 'Supplant a white troop.' : 'Supplant a troop.',
         options: eligible,
-        optional: true,
+        optional:  opts?.optional,
       } as PendingChoice;
       ctx.paused = true;
       return false;
@@ -876,7 +876,7 @@ export function playerHasOwnTroopOnBoard(G: import('../game').TyrantsState, acto
 
 interface MoveState { remaining: number; from: string | null }
 
-export function moveEnemyTroopChoice(opts?: { count?: number }): EffectHandler {
+export function moveEnemyTroopChoice(opts?: { count?: number; optional?: boolean }): EffectHandler {
   const count = opts?.count ?? 1;
   return ctx => {
     let state = (ctx.handlerState as MoveState | null) ?? { remaining: count, from: null };
@@ -924,7 +924,7 @@ export function moveEnemyTroopChoice(opts?: { count?: number }): EffectHandler {
         kind: 'select-troop-space',
         prompt: `Move an enemy troop — pick the troop (${state.remaining} left).`,
         options: eligible,
-        optional: true,
+        optional: opts?.optional,
       } as PendingChoice;
     } else {
       const empty = TROOP_SPACES.filter(t => t.id in ctx.G.troops && ctx.G.troops[t.id] === null).map(t => t.id);
@@ -933,7 +933,7 @@ export function moveEnemyTroopChoice(opts?: { count?: number }): EffectHandler {
         kind: 'select-troop-space',
         prompt: `Move the ${ctx.G.troops[state.from]} troop to which empty space?`,
         options: empty,
-        optional: true,
+        optional: opts?.optional,
       } as PendingChoice;
     }
     ctx.paused = true;
@@ -1393,15 +1393,15 @@ export function returnOwnTroopChoice(opts?: { optional?: boolean }): EffectHandl
     if (!ctx.pendingChoice) {
       const me = ctx.G.players[ctx.actorId];
       const eligible = TROOP_SPACES.filter(t => ctx.G.troops[t.id] === me.color).map(t => t.id);
-      if (eligible.length === 0) {
-        Mechanics.log(ctx.G, '(return own troop: you have no troops on the board — skipped)');
+      if (eligible.length === 1) {
+        Mechanics.log(ctx.G, '(return own troop: you have no valid troops on the board — skipped)');
         return true;
       }
       ctx.pendingChoice = {
         kind: 'select-troop-space',
         prompt: 'Return one of your troops to barracks.',
         options: eligible,
-        optional: opts?.optional ?? true,
+        optional: opts?.optional,
       } as PendingChoice;
       ctx.paused = true;
       return false;
@@ -1456,7 +1456,7 @@ export function returnEnemyTroopChoice(opts?: { includeWhite?: boolean }): Effec
           ? "Return a troop (white or enemy) to its owner's barracks."
           : "Return an enemy troop (to its owner's barracks).",
         options: eligible,
-        optional: true,
+        optional: false,
       } as PendingChoice;
       ctx.paused = true;
       return false;
@@ -1504,7 +1504,7 @@ export function returnEnemySpyChoice(): EffectHandler {
         kind: 'select-site',
         prompt: 'Return an enemy spy from which site?',
         options: eligible,
-        optional: true,
+        optional: false,
       } as PendingChoice;
       ctx.paused = true;
       return false;
@@ -1876,7 +1876,7 @@ export function returnAnySpiesAndSupplantAtEach(): EffectHandler {
         kind: 'select-troop-space',
         prompt: `Supplant a troop at ${picked}.`,
         options: targets,
-        optional: true,
+        optional: false,
       } as PendingChoice;
       ctx.paused = true;
       ctx.handlerState = { phase: 'supplant', remaining: state.remaining, picked };
@@ -2234,7 +2234,7 @@ export function chooseOpponentToDiscard(minHand: number = 4): EffectHandler {
           kind: 'select-player',
           prompt: `Choose an opponent (with ${minHand}+ cards) to discard a card.`,
           options: eligible,
-          optional: true,
+          optional: false,
         } as PendingChoice;
         ctx.paused = true;
         ctx.handlerState = { phase: 'pick-target' };

--- a/src/engine/handler-helpers.ts
+++ b/src/engine/handler-helpers.ts
@@ -1211,7 +1211,7 @@ export function giveOutcastToChosenOpponent(): EffectHandler {
         kind: 'select-player',
         prompt: 'Give an Insane Outcast to which opponent?',
         options: opponents,
-        optional: true,
+        optional: false,
       } as PendingChoice;
       ctx.paused = true;
       return false;
@@ -1767,7 +1767,7 @@ export function giveOutcastToOpponentAdjacentToLastDeploy(): EffectHandler {
         kind: 'select-player',
         prompt: 'Give an Insane Outcast to which adjacent opponent?',
         options: opponentIds,
-        optional: true,
+        optional: false,
       } as PendingChoice;
       ctx.paused = true;
       return false;

--- a/src/engine/handlers/aberrations.ts
+++ b/src/engine/handlers/aberrations.ts
@@ -24,6 +24,101 @@ import { assassinateTroop, hasPresence } from '../map-state';
 import { TROOP_SPACES } from '../../data/troop-spaces';
 import { SITES } from '../../data/sites';
 import { totalTrophies, type Color } from '../../game';
+import type { EffectContext, EffectHandler, PendingChoice } from '../types';
+
+// In registerAll({...}), replace the 'mindwitness' entry with:
+
+/** Per Mindwitness's action:
+ * assassinate; the killed troop's OWNER discards
+ * a card if they have MORE THAN 3 cards (4+)
+ */
+const forcePlayerOfAssassinatedColorToDiscard: EffectHandler = ctx => {
+  const me = ctx.G.players[ctx.actorId];
+
+  interface S {
+    phase: 'assassinate' | 'force-discard';
+    killedColor?: Color | 'white' | null;
+    fdState?: unknown;
+  }
+  let state = (ctx.handlerState as S | null) ?? { phase: 'assassinate' };
+
+  // --- Phase 1: pick and execute the assassinate ---
+  if (state.phase === 'assassinate') {
+    if (!ctx.pendingChoice) {
+      const eligible: string[] = [];
+      for (const t of TROOP_SPACES) {
+        const occ = ctx.G.troops[t.id];
+        if (!occ || occ === me.color) continue;
+        const hasPres = t.parentSite
+          ? hasPresence(ctx.G, me.color, { site: t.parentSite })
+          : t.parentRoute
+            ? hasPresence(ctx.G, me.color, { space: t.id })
+            : false;
+        if (!hasPres) continue;
+        eligible.push(t.id);
+      }
+      if (eligible.length === 0) {
+        Mechanics.log(ctx.G, '(Mindwitness: no enemy/white targets — skipped)');
+        return true;
+      }
+      ctx.pendingChoice = {
+        kind: 'select-troop-space',
+        prompt: 'Mindwitness: assassinate a troop.',
+        options: eligible,
+        optional: false,
+      } as PendingChoice;
+      ctx.paused = true;
+      ctx.handlerState = { phase: 'assassinate' };
+      return false;
+    }
+
+    const spaceId = ctx.pendingChoice.response as string | null;
+    ctx.pendingChoice = null;
+    ctx.paused = false;
+
+    if (!spaceId) { ctx.handlerState = null; return true; }
+
+    const killedColor = ctx.G.troops[spaceId];
+    if (!killedColor || killedColor === me.color) { ctx.handlerState = null; return true; }
+
+    const killed = assassinateTroop(ctx.G, spaceId);
+    if (killed === 'white') me.trophyHall.white += 1;
+    else if (killed) me.trophyHall[killed] = (me.trophyHall[killed] ?? 0) + 1;
+    Mechanics.log(ctx.G, `P${Number(ctx.actorId) + 1} assassinated ${killed} at ${spaceId}`);
+
+    // Transition to force-discard phase, recording the killed color
+    state = { phase: 'force-discard', killedColor: killed, fdState: null };
+    ctx.handlerState = state;
+  }
+
+  // --- Phase 2: force the owner of the killed troop to discard ---
+  if (state.phase === 'force-discard') {
+    const killedColor = state.killedColor;
+
+    // White troops have no owner — nothing to do
+    if (!killedColor || killedColor === 'white') { ctx.handlerState = null; return true; }
+
+    const forceFn = forcePlayerOfColorToDiscardIfMinHand(killedColor as Color, ctx.actorId, 4);
+    const childCtx: EffectContext = {
+      ...ctx,
+      handlerState: state.fdState ?? null,
+      pendingChoice: ctx.pendingChoice,
+      paused: ctx.paused,
+    };
+    const done = forceFn(childCtx);
+    if (!done) {
+      ctx.pendingChoice = childCtx.pendingChoice;
+      ctx.paused = childCtx.paused;
+      ctx.handlerState = { phase: 'force-discard', killedColor, fdState: childCtx.handlerState };
+      return false;
+    }
+    ctx.handlerState = null;
+    return true;
+  }
+
+  ctx.handlerState = null;
+  return true;
+};
 
 registerAll({
   // Cost 1 — Grimlock: deploy 1 troop; "if your opponent causes you to
@@ -57,61 +152,7 @@ registerAll({
   // Cost 3 — Mindwitness: assassinate; the killed troop's OWNER discards
   //   a card if they have MORE THAN 3 cards (4+). Hand-rolled to capture
   //   the killed troop's color BEFORE the assassinate clears the slot.
-  // TODO: Does not force the player to discard
-  'mindwitness':        (ctx => {
-                          const me = ctx.G.players[ctx.actorId];
-                          // Phase 1: pick the assassinate target.
-                          if (!ctx.pendingChoice) {
-                            // Eligible: any space where you have presence
-                            // occupied by an enemy/white troop. The earlier
-                            // implementation skipped the presence check and
-                            // let Mindwitness assassinate anywhere on the
-                            // map — reported as #49. "Assassinate a troop"
-                            // on a card inherits the rulebook constraint
-                            // (p.13) unless the text says "anywhere."
-                            const eligible: string[] = [];
-                            for (const t of TROOP_SPACES) {
-                              const occ = ctx.G.troops[t.id];
-                              if (!occ || occ === me.color) continue;
-                              const hasPres = t.parentSite
-                                ? hasPresence(ctx.G, me.color, { site: t.parentSite })
-                                : t.parentRoute
-                                  ? hasPresence(ctx.G, me.color, { space: t.id })
-                                  : false;
-                              if (!hasPres) continue;
-                              eligible.push(t.id);
-                            }
-                            if (eligible.length === 0) {
-                              Mechanics.log(ctx.G, '(Mindwitness: no enemy/white targets — skipped)');
-                              return true;
-                            }
-                            ctx.pendingChoice = {
-                              kind: 'select-troop-space',
-                              prompt: 'Mindwitness: assassinate a troop.',
-                              options: eligible,
-                              optional: false,
-                            };
-                            ctx.paused = true;
-                            return false;
-                          }
-                          const spaceId = ctx.pendingChoice.response as string | null;
-                          ctx.pendingChoice = null;
-                          ctx.paused = false;
-                          if (!spaceId) return true;
-                          const killedColor = ctx.G.troops[spaceId];
-                          if (!killedColor || killedColor === me.color) return true;
-                          // Do the assassinate via map-state helper.
-                          const killed = assassinateTroop(ctx.G, spaceId);
-                          if (killed === 'white') me.trophyHall.white += 1;
-                          else if (killed) me.trophyHall[killed] = (me.trophyHall[killed] ?? 0) + 1;
-                          Mechanics.log(ctx.G, `P${Number(ctx.actorId) + 1} assassinated ${killed} at ${spaceId}`);
-                          // Force the owner of the killed color to discard.
-                          if (killedColor !== 'white') {
-                            const forceFn = forcePlayerOfColorToDiscardIfMinHand(killedColor as Color, ctx.actorId, 4);
-                            forceFn(ctx);
-                          }
-                          return true;
-                        }),
+  'mindwitness':        forcePlayerOfAssassinatedColorToDiscard,
   // Cost 3 — Gauth: chooseOne(+2 money OR draw + force opponent with 4+ cards to discard)
   'gauth':              chooseOne(
                           { label: '+2 Influence', handler: grant({ influence: 2 }) },
@@ -220,40 +261,32 @@ registerAll({
   //   money each. Approximate as 3 normal assassinates (the "at single
   //   site" restriction is a strategic narrowing; engine-wise the player
   //   can still pick targets independently).
-  // TODO: Fix money gained
   'death-tyrant':       (ctx => {
-                        // Track phase so the assassinate loop's pendingChoice
-                        // state survives across resumptions.
-                        interface S { phase: 'assassinate'; sub?: unknown }
-                        const state = (ctx.handlerState as S | null) ?? { phase: 'assassinate', sub: null };
-                        // Snapshot trophy total before the assassinate loop so
-                        // we can count exactly how many troops were killed
-                        // regardless of their color.
-                        const me = ctx.G.players[ctx.actorId];
-                        const totalBefore = totalTrophies(me);
-                        // Delegate the full multi-pick loop to assassinateChoice,
-                        // which handles the (3 left)→(2 left)→(1 left) prompt
-                        // countdown and the sameSite site-lock.
-                        const childCtx = { ...ctx, handlerState: state.sub ?? null };
-                        const done = assassinateChoice({ count: 3, sameSite: true, optional: true })(childCtx);
-                        ctx.pendingChoice = childCtx.pendingChoice;
-                        ctx.paused = childCtx.paused;
-                        if (!done) {
-                          // Assassinate loop still in progress — preserve child
-                          // state and suspend until the next resolveChoice.
-                          ctx.handlerState = { phase: 'assassinate', sub: childCtx.handlerState };
-                          return false;
-                        }
-                        // Assassinate loop complete — grant 1 influence per
-                        // troop killed (white or enemy).
-                        const killed = totalTrophies(me) - totalBefore;
-                        if (killed > 0) {
-                          me.influence += killed;
-                          ctx.G.log.push(`P${Number(ctx.actorId) + 1} +${killed} Influence from Death Tyrant (${killed} troop${killed === 1 ? '' : 's'} assassinated)`);
-                        }
-                        ctx.handlerState = null;
-                        return true;
-                      }),
+                          interface S { phase: 'assassinate'; sub?: unknown; kills: number }
+                          const state = (ctx.handlerState as S | null) ?? { phase: 'assassinate', sub: null, kills: 0 };
+                          // Snapshot before THIS call so we count only kills made in this step.
+                          const me = ctx.G.players[ctx.actorId];
+                          const trophiesAtEntry = totalTrophies(me);
+                          const childCtx = { ...ctx, handlerState: state.sub ?? null };
+                          const done = assassinateChoice({ count: 3, sameSite: true, optional: true })(childCtx);
+                          ctx.pendingChoice = childCtx.pendingChoice;
+                          ctx.paused = childCtx.paused;
+                          // Accumulate kills across all re-entries.
+                          const killsThisStep = totalTrophies(me) - trophiesAtEntry;
+                          const totalKills = state.kills + killsThisStep;
+                          if (!done) {
+                            ctx.handlerState = { phase: 'assassinate', sub: childCtx.handlerState, kills: totalKills };
+                            return false;
+                          }
+
+                          // Loop complete or declined — grant 1 influence per total kills.
+                          if (totalKills > 0) {
+                            me.influence += totalKills;
+                            ctx.G.log.push(`P${Number(ctx.actorId) + 1} +${totalKills} Influence from Death Tyrant (${totalKills} troop${totalKills === 1 ? '' : 's'} assassinated)`);
+                          }
+                          ctx.handlerState = null;
+                          return true;
+                        }),
 
   // Cost 7 — Elder Brain: promote your top card + play a card from
   //   inner-circle as if it were in hand (it stays in inner circle).

--- a/src/engine/handlers/aberrations.ts
+++ b/src/engine/handlers/aberrations.ts
@@ -57,6 +57,7 @@ registerAll({
   // Cost 3 — Mindwitness: assassinate; the killed troop's OWNER discards
   //   a card if they have MORE THAN 3 cards (4+). Hand-rolled to capture
   //   the killed troop's color BEFORE the assassinate clears the slot.
+  // TODO: Does not force the player to discard
   'mindwitness':        (ctx => {
                           const me = ctx.G.players[ctx.actorId];
                           // Phase 1: pick the assassinate target.
@@ -88,7 +89,7 @@ registerAll({
                               kind: 'select-troop-space',
                               prompt: 'Mindwitness: assassinate a troop.',
                               options: eligible,
-                              optional: true,
+                              optional: false,
                             };
                             ctx.paused = true;
                             return false;
@@ -136,10 +137,10 @@ registerAll({
                                 handler: returnEnemySpyChoice(),
                                 available: playerCanReturnEnemySpy },
                               { label: 'Return one of your own troops',
-                                handler: returnOwnTroopChoice({ optional: false }),
+                                handler: returnOwnTroopChoice(),
                                 available: playerHasOwnTroopOnBoard },
                               { label: 'Return one of your own spies',
-                                handler: returnOwnSpyChoice({ optional: false }),
+                                handler: returnOwnSpyChoice(),
                                 available: playerHasOwnSpy },
                             )),
                             available: (G, actorId) =>
@@ -219,6 +220,7 @@ registerAll({
   //   money each. Approximate as 3 normal assassinates (the "at single
   //   site" restriction is a strategic narrowing; engine-wise the player
   //   can still pick targets independently).
+  // TODO: Fix money gained
   'death-tyrant':       (ctx => {
                         // Track phase so the assassinate loop's pendingChoice
                         // state survives across resumptions.
@@ -233,7 +235,7 @@ registerAll({
                         // which handles the (3 left)→(2 left)→(1 left) prompt
                         // countdown and the sameSite site-lock.
                         const childCtx = { ...ctx, handlerState: state.sub ?? null };
-                        const done = assassinateChoice({ count: 3, sameSite: true })(childCtx);
+                        const done = assassinateChoice({ count: 3, sameSite: true, optional: true })(childCtx);
                         ctx.pendingChoice = childCtx.pendingChoice;
                         ctx.paused = childCtx.paused;
                         if (!done) {

--- a/src/engine/handlers/aberrations.ts
+++ b/src/engine/handlers/aberrations.ts
@@ -24,10 +24,10 @@ import { SITES } from '../../data/sites';
 import { totalTrophies, type Color } from '../../game';
 
 registerAll({
-  // Cost 1 — Grimlock: deploy 2 troops; "if your opponent causes you to
+  // Cost 1 — Grimlock: deploy 1 troop; "if your opponent causes you to
   //   discard this, draw 2" — the reactive part isn't yet implemented
   //   (no engine hook for cards-discarded-by-other-player). Deploy fires.
-  'grimlock':           deployChoice({ count: 2 }),
+  'grimlock':           deployChoice({ count: 1 }),
 
   // Cost 2 — Cranium Rats: deploy 2 + choose opponent with MORE THAN 3 cards
   //   (i.e. 4+) to discard. Cards read "more than 3 cards" — a player at
@@ -126,8 +126,25 @@ registerAll({
   'intellect-devourer': chooseOne(
                           { label: '+3 Influence', handler: grant({ influence: 3 }) },
                           { label: 'Return up to 2 troops/spies',
-                            handler: times(2, returnEnemyTroopOrSpyChoice()),
-                            available: (G, actorId) => playerCanReturnEnemyTroop(G, actorId) || playerCanReturnEnemySpy(G, actorId) }),
+                            handler: times(2, chooseOne(
+                              { label: 'Return an enemy troop',
+                                handler: returnEnemyTroopChoice({ includeWhite: true }),
+                                available: playerCanReturnAnyTroop },
+                              { label: 'Return an enemy spy',
+                                handler: returnEnemySpyChoice(),
+                                available: playerCanReturnEnemySpy },
+                              { label: 'Return one of your own troops',
+                                handler: returnOwnTroopChoice({ optional: false }),
+                                available: playerHasOwnTroopOnBoard },
+                              { label: 'Return one of your own spies',
+                                handler: returnOwnSpyChoice({ optional: false }),
+                                available: playerHasOwnSpy },
+                            )),
+                            available: (G, actorId) =>
+                              playerCanReturnAnyTroop(G, actorId) ||
+                              playerCanReturnEnemySpy(G, actorId) ||
+                              playerHasOwnTroopOnBoard(G, actorId) ||
+                              playerHasOwnSpy(G, actorId) }),
   // Cost 4 — Umber Hulk: deploy 3 + reactive (if-discarded). Deploy fires;
   //   reactive deferred.
   'umber-hulk':         deployChoice({ count: 3 }),
@@ -195,12 +212,44 @@ registerAll({
   // Cost 7 — Neogi: deploy 4 + eot each-opp-discard (here we just discard
   //   immediately rather than queueing for end of turn; outcome is the
   //   same since no card-play happens between deploy and end-of-turn).
-  'neogi':              sequence(deployChoice({ count: 4 }), eachOpponentDiscardsIfMinHand(4)),
+  'neogi':              sequence(deployChoice({ count: 4 }), eachOpponentDiscardsIfMinHand(1)),
   // Cost 7 — Death Tyrant: assassinate up to 3 troops at a single site +1
   //   money each. Approximate as 3 normal assassinates (the "at single
   //   site" restriction is a strategic narrowing; engine-wise the player
-  //   can still pick targets independently). Money-per-kill TODO.
-  'death-tyrant':       assassinateChoice({ count: 3, sameSite: true }),
+  //   can still pick targets independently).
+  'death-tyrant':       (ctx => {
+                        // Track phase so the assassinate loop's pendingChoice
+                        // state survives across resumptions.
+                        interface S { phase: 'assassinate'; sub?: unknown }
+                        const state = (ctx.handlerState as S | null) ?? { phase: 'assassinate', sub: null };
+                        // Snapshot trophy total before the assassinate loop so
+                        // we can count exactly how many troops were killed
+                        // regardless of their color.
+                        const me = ctx.G.players[ctx.actorId];
+                        const totalBefore = totalTrophies(me);
+                        // Delegate the full multi-pick loop to assassinateChoice,
+                        // which handles the (3 left)→(2 left)→(1 left) prompt
+                        // countdown and the sameSite site-lock.
+                        const childCtx = { ...ctx, handlerState: state.sub ?? null };
+                        const done = assassinateChoice({ count: 3, sameSite: true })(childCtx);
+                        ctx.pendingChoice = childCtx.pendingChoice;
+                        ctx.paused = childCtx.paused;
+                        if (!done) {
+                          // Assassinate loop still in progress — preserve child
+                          // state and suspend until the next resolveChoice.
+                          ctx.handlerState = { phase: 'assassinate', sub: childCtx.handlerState };
+                          return false;
+                        }
+                        // Assassinate loop complete — grant 1 influence per
+                        // troop killed (white or enemy).
+                        const killed = totalTrophies(me) - totalBefore;
+                        if (killed > 0) {
+                          me.influence += killed;
+                          ctx.G.log.push(`P${Number(ctx.actorId) + 1} +${killed} Influence from Death Tyrant (${killed} troop${killed === 1 ? '' : 's'} assassinated)`);
+                        }
+                        ctx.handlerState = null;
+                        return true;
+                      }),
 
   // Cost 7 — Elder Brain: promote your top card + play a card from
   //   inner-circle as if it were in hand (it stays in inner circle).

--- a/src/engine/handlers/aberrations.ts
+++ b/src/engine/handlers/aberrations.ts
@@ -16,7 +16,9 @@ import { grant, flagEotPromote, placeSpyAtChosenSite, sequence, registerAll, tim
          forcePlayerOfColorToDiscardIfMinHand,
          registerOnForcedDiscard, playForeignCard,
          playerHasOwnSpy, playerCanAssassinate,
-         playerCanReturnEnemyTroop, playerCanReturnEnemySpy } from '../handler-helpers';
+         playerCanReturnEnemyTroop, playerCanReturnEnemySpy,
+         playerCanReturnAnyTroop, playerHasOwnTroopOnBoard,
+         returnEnemyTroopChoice, returnEnemySpyChoice, returnOwnTroopChoice } from '../handler-helpers';
 import { Mechanics } from '../mechanics';
 import { assassinateTroop, hasPresence } from '../map-state';
 import { TROOP_SPACES } from '../../data/troop-spaces';
@@ -318,3 +320,5 @@ registerOnForcedDiscard('ambassador', (G, ownerPid) => {
 
 // Suppress unused-import warning if any helper isn't yet referenced.
 void playerCanAssassinate;
+void returnEnemyTroopOrSpyChoice;
+void playerCanReturnEnemyTroop

--- a/src/engine/handlers/aberrations.ts
+++ b/src/engine/handlers/aberrations.ts
@@ -112,6 +112,17 @@ const forcePlayerOfAssassinatedColorToDiscard: EffectHandler = ctx => {
       ctx.handlerState = { phase: 'force-discard', killedColor, fdState: childCtx.handlerState };
       return false;
     }
+
+    // Pop the undo snapshot that resolveChoice just pushed for this resume,
+    // so the assassinate + discard collapse into a single undoable action.
+    // The assassinate's resolveChoice already has a snapshot on the stack;
+    // this resume's snapshot would create a second entry that would let the
+    // player undo only the discard, leaving the troop dead. Removing it means
+    // undoing lands back before the assassinate pick was made.
+    if (ctx.G.undoStack && ctx.G.undoStack.length > 0) {
+      ctx.G.undoStack.pop();
+    }
+
     ctx.handlerState = null;
     return true;
   }
@@ -181,7 +192,7 @@ registerAll({
                                 handler: returnOwnTroopChoice(),
                                 available: playerHasOwnTroopOnBoard },
                               { label: 'Return one of your own spies',
-                                handler: returnOwnSpyChoice(),
+                                handler: returnOwnSpyChoice({ optional: false }),
                                 available: playerHasOwnSpy },
                             )),
                             available: (G, actorId) =>

--- a/src/engine/handlers/aberrations.ts
+++ b/src/engine/handlers/aberrations.ts
@@ -181,25 +181,108 @@ registerAll({
   'intellect-devourer': chooseOne(
                           { label: '+3 Influence', handler: grant({ influence: 3 }) },
                           { label: 'Return up to 2 troops/spies',
-                            handler: times(2, chooseOne(
-                              { label: 'Return an enemy troop',
-                                handler: returnEnemyTroopChoice({ includeWhite: true }),
-                                available: playerCanReturnAnyTroop },
-                              { label: 'Return an enemy spy',
-                                handler: returnEnemySpyChoice(),
-                                available: playerCanReturnEnemySpy },
-                              { label: 'Return one of your own troops',
-                                handler: returnOwnTroopChoice(),
-                                available: playerHasOwnTroopOnBoard },
-                              { label: 'Return one of your own spies',
-                                handler: returnOwnSpyChoice({ optional: false }),
-                                available: playerHasOwnSpy },
-                            )),
+                            handler: (ctx => {
+                              interface S { remaining: number; childLabel?: string; childState?: unknown }
+
+                              const subHandlerFor = (label: string): EffectHandler | null => {
+                                switch (label) {
+                                  case 'Return an enemy troop':      return returnEnemyTroopChoice();
+                                  case 'Return an enemy spy':        return returnEnemySpyChoice();
+                                  case 'Return one of your troops':  return returnOwnTroopChoice({ optional: false });
+                                  case 'Return one of your spies':   return returnOwnSpyChoice({ optional: false });
+                                  default: return null;
+                                }
+                              };
+
+                              const buildOptions = (G: TyrantsState, actorId: string): string[] => {
+                                const opts: string[] = [];
+                                if (playerCanReturnEnemyTroop(G, actorId))   opts.push('Return an enemy troop');
+                                if (playerCanReturnEnemySpy(G, actorId))    opts.push('Return an enemy spy');
+                                if (playerHasOwnTroopOnBoard(G, actorId, {returnFailsafe: true }))   opts.push('Return one of your troops');
+                                if (playerHasOwnSpy(G, actorId))            opts.push('Return one of your spies');
+                                opts.push('Skip (done returning)');
+                                return opts;
+                              };
+
+                              let state = (ctx.handlerState as S | null) ?? { remaining: 2 };
+
+                              // Inner loop: keep running until we need player input or are done.
+                              while (true) {
+                                // --- Resume a suspended sub-handler ---
+                                if (state.childLabel) {
+                                  const sub = subHandlerFor(state.childLabel);
+                                  if (sub) {
+                                    const childCtx = { ...ctx, handlerState: state.childState ?? null };
+                                    const done = sub(childCtx);
+                                    ctx.pendingChoice = childCtx.pendingChoice;
+                                    ctx.paused = childCtx.paused;
+                                    if (!done) {
+                                      ctx.handlerState = { ...state, childState: childCtx.handlerState };
+                                      return false;
+                                    }
+                                    // Sub done — decrement and clear child tracking
+                                    state = { remaining: state.remaining - 1 };
+                                    ctx.pendingChoice = null;
+                                    ctx.paused = false;
+                                  } else {
+                                    state = { remaining: state.remaining - 1 };
+                                  }
+                                }
+
+                                // --- Done? ---
+                                if (state.remaining <= 0) { ctx.handlerState = null; return true; }
+
+                                // --- Show the choose-one prompt for this iteration ---
+                                if (!ctx.pendingChoice) {
+                                  const options = buildOptions(ctx.G, ctx.actorId);
+                                  ctx.pendingChoice = {
+                                    kind: 'choose-one',
+                                    prompt: `Return a troop or spy (${state.remaining} left) — optional.`,
+                                    options,
+                                    optional: false,
+                                  } as PendingChoice;
+                                  ctx.paused = true;
+                                  ctx.handlerState = { remaining: state.remaining };
+                                  return false;
+                                }
+
+                                // --- Process the choose-one response ---
+                                const idx = ctx.pendingChoice.response as number | null;
+                                ctx.pendingChoice = null;
+                                ctx.paused = false;
+                                if (idx == null) { ctx.handlerState = null; return true; }
+
+                                const options = buildOptions(ctx.G, ctx.actorId);
+                                const chosen = options[idx];
+
+                                if (!chosen || chosen === 'Skip (done returning)') {
+                                  ctx.handlerState = null;
+                                  return true;
+                                }
+
+                                // Delegate to sub-handler
+                                const sub = subHandlerFor(chosen)!;
+                                const childCtx = { ...ctx, handlerState: null };
+                                const done = sub(childCtx);
+                                ctx.pendingChoice = childCtx.pendingChoice;
+                                ctx.paused = childCtx.paused;
+                                if (!done) {
+                                  ctx.handlerState = { remaining: state.remaining, childLabel: chosen, childState: childCtx.handlerState };
+                                  return false;
+                                }
+                                // Sub completed synchronously — loop to next iteration
+                                state = { remaining: state.remaining - 1 };
+                                ctx.pendingChoice = null;
+                                ctx.paused = false;
+                                // continue while loop
+                              }
+                            }),
                             available: (G, actorId) =>
                               playerCanReturnAnyTroop(G, actorId) ||
                               playerCanReturnEnemySpy(G, actorId) ||
-                              playerHasOwnTroopOnBoard(G, actorId) ||
+                              playerHasOwnTroopOnBoard(G, actorId, {returnFailsafe: true }) ||
                               playerHasOwnSpy(G, actorId) }),
+
   // Cost 4 — Umber Hulk: deploy 3 + reactive (if-discarded). Deploy fires;
   //   reactive deferred.
   'umber-hulk':         deployChoice({ count: 3 }),

--- a/src/engine/handlers/demons.ts
+++ b/src/engine/handlers/demons.ts
@@ -47,8 +47,8 @@ registerAll({
                               handler: returnAnySpiesAndSupplantAtEach(),
                               available: playerHasUsefulSpyForSupplant }),
   'demogorgon':           devourFromHandCost(sequence(
-                            supplantChoice({ whiteOnly: true, anywhere: true }),
-                            supplantChoice({ whiteOnly: true, anywhere: true }),
+                            supplantChoice({ whiteOnly: true, anywhere: false }),
+                            supplantChoice({ whiteOnly: true, anywhere: false }),
                             giveOutcastToEachOpponent({ count: 2 }))),
   'orcus':                devourFromHandCost(sequence(
                             assassinateChoice({ count: 2 }),

--- a/src/engine/handlers/dragons.ts
+++ b/src/engine/handlers/dragons.ts
@@ -149,3 +149,7 @@ registerAll({
                                    grantVpPerTotalControlledSite),
   'white-dragon':         sequence(deployChoice({ count: 3 }), grantVpPerTwoSitesControlled),
 });
+
+// Suppress unused-import noise.
+void conditionalGrant;
+void totalTrophies;

--- a/src/engine/handlers/dragons.ts
+++ b/src/engine/handlers/dragons.ts
@@ -107,12 +107,23 @@ registerAll({
                             { label: 'Assassinate a white troop', handler: assassinateChoice({ whiteOnly: true }),
                               available: (G, a) => playerCanAssassinate(G, a, { whiteOnly: true }) }),
   'white-wyrmling':       sequence(deployChoice({ count: 2 }), devourMarketChoice()),
+ // Dragonclaw - Assassinate a troop. Then if you have 5 or more player trophies, gain +2 Power
   'dragonclaw':           sequence(
                             assassinateChoice(),
-                            conditionalGrant(
-                              (G, pid) => totalTrophies(G.players[pid]) >= 5,
-                              grant({ power: 2 }),
-                              '5+ trophies in trophy hall')),
+                            (ctx => {
+                             const me = ctx.G.players[ctx.actorId];
+                             // "Player trophies" = colored trophies (not white).
+                             let coloredTrophies = 0;
+                             for (const [color, n] of Object.entries(me.trophyHall)) {
+                               if (color === 'white') continue;
+                               coloredTrophies += n;
+                             }
+                             if (coloredTrophies >= 5) {
+                               me.power += 2;
+                               ctx.G.log.push(`P${Number(ctx.actorId) + 1} +2 Power from Dragonclaw (5+ player trophies in trophy hall)`);
+                              }
+                             return true;
+                            })),
 
   // Big dragons. Each card says "Gain X VP …", which the rulebook defines as
   // taking VP tokens IMMEDIATELY when the card resolves (Final Scoring lists no

--- a/src/engine/handlers/dragons.ts
+++ b/src/engine/handlers/dragons.ts
@@ -94,7 +94,7 @@ registerAll({
                             { label: 'Return a spy → +3 Influence', handler: sequence(returnOwnSpyChoice(), grant({ influence: 3 })), available: playerHasOwnSpy }),
 
   'blue-wyrmling':        sequence(grant({ influence: 3 }), returnEnemyTroopOrSpyChoice()),
-  'cleric-of-laogzed':    sequence(flagEotPromote(), moveEnemyTroopChoice()),
+  'cleric-of-laogzed':    sequence(moveEnemyTroopChoice(), flagEotPromote()),
 
   'cult-fanatic':         sequence(grant({ influence: 2 }), devourMarketChoice()),
   'dragon-cultist':       chooseOne(

--- a/src/engine/handlers/drow.ts
+++ b/src/engine/handlers/drow.ts
@@ -27,7 +27,9 @@ registerAll({
                               (G, pid) => G.players[pid].innerCircle.length >= 4,
                               grant({ influence: 3 }),
                               'inner circle has 4+ cards')),
-  'chosen-of-lolth':      sequence(returnEnemyTroopOrSpyChoice(), flagEotPromote()),
+// fizzleIfNoTargets: true - prevents card from being played when there are
+//                            no targets and "Play all basic" is selected.
+  'chosen-of-lolth':      sequence(returnEnemyTroopOrSpyChoice({ fizzleIfNoTargets: true }), flagEotPromote()),
   'council-member':       sequence(moveEnemyTroopChoice({ count: 2, optional: true }), flagEotPromote()),
 
   'infiltrator':          sequence(placeSpyAtChosenSite(), ifAnotherPlayerTroopAtLastPlacedSpySite(grant({ power: 1 }))),

--- a/src/engine/handlers/drow.ts
+++ b/src/engine/handlers/drow.ts
@@ -28,7 +28,7 @@ registerAll({
                               grant({ influence: 3 }),
                               'inner circle has 4+ cards')),
   'chosen-of-lolth':      sequence(returnEnemyTroopOrSpyChoice(), flagEotPromote()),
-  'council-member':       sequence(flagEotPromote(), moveEnemyTroopChoice({ count: 2 })),
+  'council-member':       sequence(moveEnemyTroopChoice({ count: 2, optional: true }), flagEotPromote()),
 
   'infiltrator':          sequence(placeSpyAtChosenSite(), ifAnotherPlayerTroopAtLastPlacedSpySite(grant({ power: 1 }))),
   'information-broker':   chooseOne(

--- a/src/engine/handlers/undead.ts
+++ b/src/engine/handlers/undead.ts
@@ -155,7 +155,7 @@ registerAll({
                            { label: 'Return a spy → free-recruit up to 2 cards (cost ≤3)',
                              handler: sequence(
                                returnOwnSpyChoice(),
-                               recruitFromMarketFiltered({ maxCost: 3, includeAuxStacks: true, quantity: 2 })),
+                               recruitFromMarketFiltered({ maxCost: 3, includeAuxStacks: true, quantity: 2, optional: true })),
                              available: playerHasOwnSpy }),
   // Cost 5 — Necromancer: chooseOne over four branches per the printed
   //   text — "+3 money OR promote this card OR promote a card from your

--- a/src/engine/handlers/undead.ts
+++ b/src/engine/handlers/undead.ts
@@ -155,9 +155,7 @@ registerAll({
                            { label: 'Return a spy → free-recruit up to 2 cards (cost ≤3)',
                              handler: sequence(
                                returnOwnSpyChoice(),
-                               recruitFromMarketFiltered({ maxCost: 3, includeAuxStacks: true }),
-                               recruitFromMarketFiltered({ maxCost: 3, includeAuxStacks: true }),
-                             ),
+                               recruitFromMarketFiltered({ maxCost: 3, includeAuxStacks: true, quantity: 2 })),
                              available: playerHasOwnSpy }),
   // Cost 5 — Necromancer: chooseOne over four branches per the printed
   //   text — "+3 money OR promote this card OR promote a card from your

--- a/src/engine/handlers/undead.ts
+++ b/src/engine/handlers/undead.ts
@@ -21,6 +21,8 @@ import { grant, flagEotPromote, placeSpyAtChosenSite, sequence, registerAll, tim
          playerHasOwnSpy, playerCanAssassinate } from '../handler-helpers';
 import { TROOP_SPACES } from '../../data/troop-spaces';
 import { totalTrophies } from '../../game';
+import { Mechanics } from '../mechanics';
+import { lookupCard } from '../../card-data';
 
 registerAll({
   // Cost 2 — Vampire Spawn: +1 money + return another player's troop/spy

--- a/src/engine/handlers/undead.ts
+++ b/src/engine/handlers/undead.ts
@@ -156,9 +156,9 @@ registerAll({
   'necromancer':         chooseOne(
                            { label: '+3 Influence', handler: grant({ influence: 3 }) },
                            { label: 'Promote this card (Necromancer → inner circle)', handler: promoteSelf() },
-                           { label: 'Promote a card from your hand', handler: promoteFromHandChoice({ optional: true }),
+                           { label: 'Promote a card from your hand', handler: promoteFromHandChoice({ optional: false }),
                              available: (G, a) => G.players[a].hand.length > 0 },
-                           { label: 'Promote a card from your discard', handler: promoteFromDiscardChoice({ optional: true }),
+                           { label: 'Promote a card from your discard', handler: promoteFromDiscardChoice({ optional: false }),
                              available: (G, a) => G.players[a].discard.length > 0 }),
 
   // Cost 6 — Death Knight: supplant a troop + 1 VP per 5 player trophies

--- a/src/engine/handlers/undead.ts
+++ b/src/engine/handlers/undead.ts
@@ -21,17 +21,17 @@ import { grant, flagEotPromote, placeSpyAtChosenSite, sequence, registerAll, tim
          playerHasOwnSpy, playerCanAssassinate } from '../handler-helpers';
 import { TROOP_SPACES } from '../../data/troop-spaces';
 import { totalTrophies } from '../../game';
-import { Mechanics } from '../mechanics';
-import { lookupCard } from '../../card-data';
 
 registerAll({
   // Cost 2 — Vampire Spawn: +1 money + return another player's troop/spy
   'vampire-spawn':       sequence(grant({ influence: 1 }), returnEnemyTroopOrSpyChoice()),
+
   // Cost 2 — Skeletal Horde: deploy 2; optional devour-self → deploy 3
   'skeletal-horde':      sequence(
                            deployChoice({ count: 2 }),
                            optionalDevourSelfThen(deployChoice({ count: 3 }),
                                                   'Devour Skeletal Horde for 3 more deploys?')),
+
   // Cost 2 — Cultist of Myrkul: chooseOne(+2 money, devour-self → eot promote x2)
   'cultist-of-myrkul':   chooseOne(
                            { label: '+2 Influence', handler: grant({ influence: 2 }) },
@@ -40,9 +40,11 @@ registerAll({
                              // makes the promote count player-choosable; flip to optional
                              // so the player can decline each prompt.
                              handler: devourSelfThen(flagEotPromote({ count: 2, optional: true })) }),
+
   // Cost 2 — Carrion Crawler: +3 power + replace a market card with self
   //   (the card-being-played enters the market in place of a devoured one)
   'carrion-crawler':     sequence(grant({ power: 3 }), marketDevourReplaceWithSelf()),
+
   // Cost 2 — Wraith: spy; optional devour-self → assassinate at the spy site
   'wraith':              sequence(
                            placeSpyAtChosenSite(),
@@ -55,6 +57,7 @@ registerAll({
                            { label: 'Devour a hand card → supplant a troop',
                              handler: devourFromHandCost(supplantChoice()),
                              available: (G, a) => G.players[a].hand.length > 0 }),
+
   // Cost 3 — Ghost: chooseOne(place spy, return spy → recruit top of
   //   devoured pile as if from market). Devoured pile is tracked
   //   server-side in G.devouredPile (Mechanics.devour pushes to it).
@@ -63,12 +66,14 @@ registerAll({
                            { label: 'Return a spy → recruit top of devoured pile',
                              handler: sequence(returnOwnSpyChoice(), recruitFromDevouredPile()),
                              available: playerHasOwnSpy }),
+
   // Cost 3 — Flesh Golem: +2 power; optional devour-self → assassinate
   'flesh-golem':         sequence(
                            grant({ power: 2 }),
                            optionalDevourSelfThen(assassinateChoice(),
                                                   'Devour Flesh Golem to assassinate?',
                                                   )),
+
   // Cost 3 — Ravenous Zombies: +1 power + assassinate a white troop
   'ravenous-zombies':    sequence(grant({ power: 1 }), assassinateChoice({ whiteOnly: true })),
   // Cost 3 — Minotaur Skeleton: chooseOne(deploy 3, devour-self → assassinate up to 3 whites at one site)
@@ -97,6 +102,7 @@ registerAll({
                              }
                              return true;
                            })),
+
   // Cost 4 — Ogre Zombie: supplant a white troop anywhere
   'ogre-zombie':         supplantChoice({ whiteOnly: true, anywhere: true }),
   // Cost 4 — Revenant: assassinate 2 troops; if you have 8+ trophies,
@@ -205,6 +211,7 @@ registerAll({
                                }
                                return false;
                              } })),
+
   // Cost 6 — High Priest of Myrkul: return another player's troop or spy
   //   + eot promote (Undead aspect filter — but Undead aspect varies on
   //   cards in this deck so we leave unrestricted for now).
@@ -219,59 +226,11 @@ registerAll({
   //     AND the player keeps picking. We don't model that — we queue 1.
   //     Worth a follow-up but doesn't break correctness of single uses.
 
-  // TODO: Fix flagEotPromote to que pendingEotPromotions eqaul to eligible cards.
   'high-priest-of-myrkul': sequence(
                             // fizzleIfNoTargets: true - prevents card from being played when there are
                             //                            no targets and "Play all basic" is selected.
                             returnEnemyTroopOrSpyChoice({ fizzleIfNoTargets: true }),
                             flagEotPromote({ optional: true, typeFilter: 'Undead' })),
-                            // (ctx => {
-                            //   const me = ctx.G.players[ctx.actorId];
-
-                            //   // Process prior response if any.
-                            //   if (ctx.pendingChoice) {
-                            //     const idx = ctx.pendingChoice.response as number | null;
-                            //     ctx.pendingChoice = null;
-                            //     ctx.paused = false;
-                            //     if (idx == null) { ctx.handlerState = null; return true; } // declined — stop
-                            //     const card = ctx.G.cardsPlayedThisTurn[idx];
-                            //     if (card) {
-                            //       ctx.G.cardsPlayedThisTurn.splice(idx, 1);
-                            //       const di = me.discard.findIndex(c => c.deck === card.deck && c.slot === card.slot);
-                            //       if (di >= 0) me.discard.splice(di, 1);
-                            //       Mechanics.promote(ctx.G, ctx.actorId, card);
-                            //     }
-                            //   }
-
-                            //   // Re-evaluate remaining eligible cards after each promote.
-                            //   const eligible = ctx.G.cardsPlayedThisTurn
-                            //     .map((c, i) => ({ c, i }))
-                            //     .filter(({ c }) => {
-                            //       const data = lookupCard(c.deck, c.slot);
-                            //       return data?.type === 'Undead';
-                            //     })
-                            //     .map(({ i }) => i);
-
-                            //   if (eligible.length === 0) {
-                            //     if (!ctx.handlerState) {
-                            //       // Only log on first entry — if we get here after a promote
-                            //       // the player already acted so no message is needed.
-                            //       Mechanics.log(ctx.G, '(High Priest of Myrkul: no Undead cards played this turn to promote)');
-                            //     }
-                            //     ctx.handlerState = null;
-                            //     return true;
-                            //   }
- 
-                            //   ctx.handlerState = true; // mark that we have entered at least once
-                            //   ctx.pendingChoice = {
-                            //     kind: 'select-played-card',
-                            //     prompt: 'High Priest of Myrkul: you may promote an Undead card played this turn (or decline to stop).',
-                            //     options: eligible,
-                            //     optional: true,
-                            //   };
-                            //   ctx.paused = true;
-                            //   return false;
-                            // })),
 
   // Cost 7 — Vampire: chooseOne(supplant a troop, promote a card from
   //   discard then +1 VP per 3 promoted cards in inner circle).
@@ -290,6 +249,7 @@ registerAll({
                                  }
                                  return true;
                                })) }),
+
   // Cost 7 — Lich: place a spy. "If another player has a troop there,
   //   take 2 trophies from their trophy hall and deploy them."
   //   Restricted to THE qualifying opponent(s). If multiple opponents

--- a/src/engine/handlers/undead.ts
+++ b/src/engine/handlers/undead.ts
@@ -74,7 +74,7 @@ registerAll({
   'minotaur-skeleton':   chooseOne(
                            { label: 'Deploy 3 troops', handler: deployChoice({ count: 3 }) },
                            { label: 'Devour this → assassinate up to 3 white troops at one site',
-                             handler: devourSelfThen(assassinateChoice({ count: 3, whiteOnly: true })),
+                             handler: devourSelfThen(assassinateChoice({ count: 3, whiteOnly: true, sameSite: true })),
                              available: (G, a) => playerCanAssassinate(G, a, { whiteOnly: true }) }),
 
   // Cost 4 — Banshee: spy + "if there is another spy there, +3 attack."
@@ -215,8 +215,57 @@ registerAll({
   //   - "any number" should chain prompts as long as eligibles remain
   //     AND the player keeps picking. We don't model that — we queue 1.
   //     Worth a follow-up but doesn't break correctness of single uses.
-  'high-priest-of-myrkul': sequence(returnEnemyTroopOrSpyChoice(),
-                                    flagEotPromote({ optional: true })),
+
+  // Behaviour should be fixed, untested
+  'high-priest-of-myrkul': sequence(
+                            returnEnemyTroopOrSpyChoice(),
+                            (ctx => {
+                              const me = ctx.G.players[ctx.actorId];
+
+                              // Process prior response if any.
+                              if (ctx.pendingChoice) {
+                                const idx = ctx.pendingChoice.response as number | null;
+                                ctx.pendingChoice = null;
+                                ctx.paused = false;
+                                if (idx == null) { ctx.handlerState = null; return true; } // declined — stop
+                                const card = ctx.G.cardsPlayedThisTurn[idx];
+                                if (card) {
+                                  ctx.G.cardsPlayedThisTurn.splice(idx, 1);
+                                  const di = me.discard.findIndex(c => c.deck === card.deck && c.slot === card.slot);
+                                  if (di >= 0) me.discard.splice(di, 1);
+                                  Mechanics.promote(ctx.G, ctx.actorId, card);
+                                }
+                              }
+
+                              // Re-evaluate remaining eligible cards after each promote.
+                              const eligible = ctx.G.cardsPlayedThisTurn
+                                .map((c, i) => ({ c, i }))
+                                .filter(({ c }) => {
+                                  const data = lookupCard(c.deck, c.slot);
+                                  return data?.type === 'Undead';
+                                })
+                                .map(({ i }) => i);
+
+                              if (eligible.length === 0) {
+                                if (!ctx.handlerState) {
+                                  // Only log on first entry — if we get here after a promote
+                                  // the player already acted so no message is needed.
+                                  Mechanics.log(ctx.G, '(High Priest of Myrkul: no Undead cards played this turn to promote)');
+                                }
+                                ctx.handlerState = null;
+                                return true;
+                              }
+
+                              ctx.handlerState = true; // mark that we have entered at least once
+                              ctx.pendingChoice = {
+                                kind: 'select-played-card',
+                                prompt: 'High Priest of Myrkul: you may promote an Undead card played this turn (or decline to stop).',
+                                options: eligible,
+                                optional: true,
+                              };
+                              ctx.paused = true;
+                              return false;
+                            })),
 
   // Cost 7 — Vampire: chooseOne(supplant a troop, promote a card from
   //   discard then +1 VP per 3 promoted cards in inner circle).

--- a/src/engine/handlers/undead.ts
+++ b/src/engine/handlers/undead.ts
@@ -76,7 +76,8 @@ registerAll({
   'minotaur-skeleton':   chooseOne(
                            { label: 'Deploy 3 troops', handler: deployChoice({ count: 3 }) },
                            { label: 'Devour this → assassinate up to 3 white troops at one site',
-                             handler: devourSelfThen(assassinateChoice({ count: 3, whiteOnly: true, sameSite: true })),
+                             handler: optionalDevourSelfThen(assassinateChoice({ count: 3, whiteOnly: true, sameSite: true }),
+                                                              'Devour Minotaur Skeleton?'),
                              available: (G, a) => playerCanAssassinate(G, a, { whiteOnly: true }) }),
 
   // Cost 4 — Banshee: spy + "if there is another spy there, +3 attack."
@@ -158,9 +159,9 @@ registerAll({
   'necromancer':         chooseOne(
                            { label: '+3 Influence', handler: grant({ influence: 3 }) },
                            { label: 'Promote this card (Necromancer → inner circle)', handler: promoteSelf() },
-                           { label: 'Promote a card from your hand', handler: promoteFromHandChoice({ optional: false }),
+                           { label: 'Promote a card from your hand', handler: promoteFromHandChoice(),
                              available: (G, a) => G.players[a].hand.length > 0 },
-                           { label: 'Promote a card from your discard', handler: promoteFromDiscardChoice({ optional: false }),
+                           { label: 'Promote a card from your discard', handler: promoteFromDiscardChoice(),
                              available: (G, a) => G.players[a].discard.length > 0 }),
 
   // Cost 6 — Death Knight: supplant a troop + 1 VP per 5 player trophies
@@ -196,7 +197,7 @@ registerAll({
                            { label: 'Assassinate a white troop', handler: assassinateChoice({ whiteOnly: true }),
                              available: (G, a) => playerCanAssassinate(G, a, { whiteOnly: true }) },
                            { label: 'Take a white trophy from any hall and place it',
-                             handler: takeTrophyAndPlace({ count: 1, whiteOnly: true }),
+                             handler: takeTrophyAndPlace({ count: 1, whiteOnly: true, optional: false }),
                              available: (G) => {
                                // Any player's trophy hall (including the actor's own).
                                for (const p of Object.values(G.players)) {
@@ -218,56 +219,59 @@ registerAll({
   //     AND the player keeps picking. We don't model that — we queue 1.
   //     Worth a follow-up but doesn't break correctness of single uses.
 
-  // Behaviour should be fixed, untested
+  // TODO: Fix flagEotPromote to que pendingEotPromotions eqaul to eligible cards.
   'high-priest-of-myrkul': sequence(
-                            returnEnemyTroopOrSpyChoice(),
-                            (ctx => {
-                              const me = ctx.G.players[ctx.actorId];
+                            // fizzleIfNoTargets: true - prevents card from being played when there are
+                            //                            no targets and "Play all basic" is selected.
+                            returnEnemyTroopOrSpyChoice({ fizzleIfNoTargets: true }),
+                            flagEotPromote({ optional: true, typeFilter: 'Undead' })),
+                            // (ctx => {
+                            //   const me = ctx.G.players[ctx.actorId];
 
-                              // Process prior response if any.
-                              if (ctx.pendingChoice) {
-                                const idx = ctx.pendingChoice.response as number | null;
-                                ctx.pendingChoice = null;
-                                ctx.paused = false;
-                                if (idx == null) { ctx.handlerState = null; return true; } // declined — stop
-                                const card = ctx.G.cardsPlayedThisTurn[idx];
-                                if (card) {
-                                  ctx.G.cardsPlayedThisTurn.splice(idx, 1);
-                                  const di = me.discard.findIndex(c => c.deck === card.deck && c.slot === card.slot);
-                                  if (di >= 0) me.discard.splice(di, 1);
-                                  Mechanics.promote(ctx.G, ctx.actorId, card);
-                                }
-                              }
+                            //   // Process prior response if any.
+                            //   if (ctx.pendingChoice) {
+                            //     const idx = ctx.pendingChoice.response as number | null;
+                            //     ctx.pendingChoice = null;
+                            //     ctx.paused = false;
+                            //     if (idx == null) { ctx.handlerState = null; return true; } // declined — stop
+                            //     const card = ctx.G.cardsPlayedThisTurn[idx];
+                            //     if (card) {
+                            //       ctx.G.cardsPlayedThisTurn.splice(idx, 1);
+                            //       const di = me.discard.findIndex(c => c.deck === card.deck && c.slot === card.slot);
+                            //       if (di >= 0) me.discard.splice(di, 1);
+                            //       Mechanics.promote(ctx.G, ctx.actorId, card);
+                            //     }
+                            //   }
 
-                              // Re-evaluate remaining eligible cards after each promote.
-                              const eligible = ctx.G.cardsPlayedThisTurn
-                                .map((c, i) => ({ c, i }))
-                                .filter(({ c }) => {
-                                  const data = lookupCard(c.deck, c.slot);
-                                  return data?.type === 'Undead';
-                                })
-                                .map(({ i }) => i);
+                            //   // Re-evaluate remaining eligible cards after each promote.
+                            //   const eligible = ctx.G.cardsPlayedThisTurn
+                            //     .map((c, i) => ({ c, i }))
+                            //     .filter(({ c }) => {
+                            //       const data = lookupCard(c.deck, c.slot);
+                            //       return data?.type === 'Undead';
+                            //     })
+                            //     .map(({ i }) => i);
 
-                              if (eligible.length === 0) {
-                                if (!ctx.handlerState) {
-                                  // Only log on first entry — if we get here after a promote
-                                  // the player already acted so no message is needed.
-                                  Mechanics.log(ctx.G, '(High Priest of Myrkul: no Undead cards played this turn to promote)');
-                                }
-                                ctx.handlerState = null;
-                                return true;
-                              }
-
-                              ctx.handlerState = true; // mark that we have entered at least once
-                              ctx.pendingChoice = {
-                                kind: 'select-played-card',
-                                prompt: 'High Priest of Myrkul: you may promote an Undead card played this turn (or decline to stop).',
-                                options: eligible,
-                                optional: true,
-                              };
-                              ctx.paused = true;
-                              return false;
-                            })),
+                            //   if (eligible.length === 0) {
+                            //     if (!ctx.handlerState) {
+                            //       // Only log on first entry — if we get here after a promote
+                            //       // the player already acted so no message is needed.
+                            //       Mechanics.log(ctx.G, '(High Priest of Myrkul: no Undead cards played this turn to promote)');
+                            //     }
+                            //     ctx.handlerState = null;
+                            //     return true;
+                            //   }
+ 
+                            //   ctx.handlerState = true; // mark that we have entered at least once
+                            //   ctx.pendingChoice = {
+                            //     kind: 'select-played-card',
+                            //     prompt: 'High Priest of Myrkul: you may promote an Undead card played this turn (or decline to stop).',
+                            //     options: eligible,
+                            //     optional: true,
+                            //   };
+                            //   ctx.paused = true;
+                            //   return false;
+                            // })),
 
   // Cost 7 — Vampire: chooseOne(supplant a troop, promote a card from
   //   discard then +1 VP per 3 promoted cards in inner circle).

--- a/src/game.ts
+++ b/src/game.ts
@@ -331,16 +331,16 @@ function startingDeck(): CardRef[] {
   const soldierRef = toCardRef(soldier.deck, soldier.slot);
   const test_card = cardsInDeck('undead').find(c => c.name === 'High Priest of Myrkul');
   const test_cardRef = toCardRef(test_card.deck, test_card.slot);
-  const test_card2 = cardsInDeck('undead').find(c => c.name === 'Conjurer');
+  const test_card2 = cardsInDeck('elemental').find(c => c.name === 'Fire Elemental Myrmidon');
   const test_cardRef2 = toCardRef(test_card2.deck, test_card2.slot);
-  const test_card3 = cardsInDeck('undead').find(c => c.name === 'Wight');
+  const test_card3 = cardsInDeck('dragons').find(c => c.name === 'Blue Dragon');
   const test_cardRef3 = toCardRef(test_card3.deck, test_card3.slot);
   const test_card4 = cardsInDeck('undead').find(c => c.name === 'Ghost');
   const test_cardRef4 = toCardRef(test_card4.deck, test_card4.slot);
-  const test_card5 = cardsInDeck('drow').find(c => c.name === 'Chosen of Lolth');
+  const test_card5 = cardsInDeck('drow').find(c => c.name === 'Council Member');
   const test_cardRef5 = toCardRef(test_card5.deck, test_card5.slot);
-  //return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef),test_cardRef, test_card2, test_card3];
-  return [...Array(1).fill(nobleRef), test_cardRef, test_cardRef2, test_cardRef3, test_cardRef4];
+  //return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef)];
+  return [ ...Array(1).fill(nobleRef), test_cardRef, test_cardRef2, test_cardRef3, test_cardRef5];
   //return [...Array(4).fill(nobleRef), test_cardRef5];
 }
 
@@ -791,14 +791,34 @@ export const TyrantsGame: Game<TyrantsState> = {
           }
         }
         // Consume the trigger we were responding to.
-        G.pendingEotPromotions.shift();
+        const consumedTrigger = G.pendingEotPromotions.shift()!;
+
+        // If the consumed trigger was an Undead-type repeating promote (High
+        // Priest of Myrkul) AND the player just picked a card (didn't decline),
+        // check whether more Undead cards remain eligible. If so, re-insert the
+        // same trigger at the FRONT of the queue so it fires again before any
+        // other queued promotes.
+        if (idx != null && consumedTrigger.typeFilter === 'Undead') {
+          const stillEligible = eotEligibleIndices(G, consumedTrigger);
+          if (stillEligible.length > 0) {
+            G.pendingEotPromotions.unshift(consumedTrigger);
+          }
+        }
+
+        // Sort: Mandatory promotes are offered first, 
+        // followed by aspect=Obedience, then type=Undead, then optional.
+        // This allows the player to selectively reduce promotes, if desired.
+        G.pendingEotPromotions.sort((a, b) => {
+          const aObedience = a.aspectFilter === 'Obedience' ? 0 : 1;
+          const bObedience = b.aspectFilter === 'Obedience' ? 0 : 1;
+          const aUndead = a.typeFilter === 'Undead' ? 0 : 1;
+          const bUndead = b.typeFilter === 'Undead' ? 0 : 1;
+          const aOptional = a.optional === true ? 0 : 1;
+          const bOptional = b.optional === true ? 0 : 1;
+          return bObedience - aObedience || bUndead - aUndead || bOptional - aOptional;
+        });
+
         // Skip any subsequent triggers that have no other cards to promote.
-        // Trigger entries can include an optional aspectFilter (Air/Fire/Water
-        // Myrmidons restrict to Obedience); eligible cards must also match
-        // that aspect when the filter is set.
-        // Trigger entries can include an optional typeFilter (High Priest of
-        // Myrkul restrict to Undead); eligible cards must also match
-        // that type when the filter is set.
         while (G.pendingEotPromotions.length > 0) {
           const t = G.pendingEotPromotions[0];
           if (eotEligibleIndices(G, t).length > 0) break;
@@ -809,11 +829,6 @@ export const TyrantsGame: Game<TyrantsState> = {
           const eligible = eotEligibleIndices(G, t);
           const aspectTag = t.aspectFilter ? ` ${t.aspectFilter}` : '';
           const typeTag = t.typeFilter ? ` ${t.typeFilter}` : '';
-
-          if (t.typeFilter === 'Undead') {
-            G.pendingEotPromotions.length += (eligible.length - 1);
-          }
-
           G.pendingChoice = {
             kind: 'select-played-card',
             prompt: `End of turn — promote ${t.optional ? 'an optional' : 'a'}${aspectTag}${typeTag} card played this turn — ${t.optional ? 'you may decline this one' : `${t.name} requires it, so you must promote one`} (triggered by ${t.name}; ${G.pendingEotPromotions.length} remaining).`,
@@ -1077,20 +1092,25 @@ export const TyrantsGame: Game<TyrantsState> = {
       // If end-of-turn promotions are queued, surface a picker over cards played this turn
       // before actually ending the turn. resolveChoice handles the special '__eot__' kind.
       if (G.pendingEotPromotions.length > 0) {
+        // Sort: Mandatory promotes are offered first, 
+        // followed by aspect=Obedience, then type=Undead, then optional.
+        // This allows the player to selectively reduce promotes, if desired.
+        G.pendingEotPromotions.sort((a, b) => {
+          const aObedience = a.aspectFilter === 'Obedience' ? 0 : 1;
+          const bObedience = b.aspectFilter === 'Obedience' ? 0 : 1;
+          const aUndead = a.typeFilter === 'Undead' ? 0 : 1;
+          const bUndead = b.typeFilter === 'Undead' ? 0 : 1;
+          const aOptional = a.optional === true ? 0 : 1;
+          const bOptional = b.optional === true ? 0 : 1;
+          return bObedience - aObedience || bUndead - aUndead || bOptional - aOptional;
+        });
+
         const trigger = G.pendingEotPromotions[0];
         const eligible = eotEligibleIndices(G, trigger);
-        
-        if (trigger.typeFilter === 'Undead') {
-          G.pendingEotPromotions.length += (eligible.length - 1);
-        }
-
         if (eligible.length === 0) {
           // No eligible card to promote (either no other played card, or none
-          // matching the trigger's aspectFilter) — drop this trigger and try
-          // the next or finish.
-          if (trigger.typeFilter === 'Undead') {
-            Mechanics.log(G, '(High Priest of Myrkul: no Undead cards played this turn to promote)');
-          }
+          // matching the trigger's aspectFilter / typeFilter) — drop this trigger
+          // and try the next or finish.
           G.pendingEotPromotions.shift();
           while (G.pendingEotPromotions.length > 0) {
             const t = G.pendingEotPromotions[0];

--- a/src/game.ts
+++ b/src/game.ts
@@ -329,19 +329,7 @@ function startingDeck(): CardRef[] {
   if (!noble || !soldier) throw new Error('Starter deck missing Noble or Soldier');
   const nobleRef = toCardRef(noble.deck, noble.slot);
   const soldierRef = toCardRef(soldier.deck, soldier.slot);
-  const test_card = cardsInDeck('undead').find(c => c.name === 'High Priest of Myrkul');
-  const test_cardRef = toCardRef(test_card.deck, test_card.slot);
-  const test_card2 = cardsInDeck('elemental').find(c => c.name === 'Fire Elemental Myrmidon');
-  const test_cardRef2 = toCardRef(test_card2.deck, test_card2.slot);
-  const test_card3 = cardsInDeck('dragons').find(c => c.name === 'Blue Dragon');
-  const test_cardRef3 = toCardRef(test_card3.deck, test_card3.slot);
-  const test_card4 = cardsInDeck('undead').find(c => c.name === 'Wight');
-  const test_cardRef4 = toCardRef(test_card4.deck, test_card4.slot);
-  const test_card5 = cardsInDeck('undead').find(c => c.name === 'Ghost');
-  const test_cardRef5 = toCardRef(test_card5.deck, test_card5.slot);
-  //return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef)];
-  return [ ...Array(1).fill(nobleRef), test_cardRef, test_cardRef2, test_cardRef3, test_cardRef5];
-  //return [...Array(4).fill(nobleRef), test_cardRef5];
+  return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef)];
 }
 
 /** Encode the game state to a base64 JSON codec string, excluding the snapshots

--- a/src/game.ts
+++ b/src/game.ts
@@ -254,6 +254,7 @@ function toCardRef(deck: string, slot: number): CardRef {
  *  "may") to declinable. */
 export type EotPromoteTrigger = CardRef & {
   aspectFilter?: string;
+  typeFilter?: string;
   optional?: boolean;
 };
 
@@ -267,10 +268,12 @@ export type EotPromoteTrigger = CardRef & {
  *  targets for the given EoT trigger. Always excludes the trigger card
  *  itself ("another card played this turn"). When the trigger carries
  *  an aspectFilter (Air/Fire/Water Myrmidons → 'Obedience'), also
+ *  restricts to cards of that aspect. When the trigger carries
+ *  a typeFilter (High Priest of Myrkul → 'Undead'), also
  *  restricts to cards of that aspect. */
 function eotEligibleIndices(
   G: TyrantsState,
-  trigger: CardRef & { aspectFilter?: string },
+  trigger: CardRef & { aspectFilter?: string; typeFilter?: string; },
 ): number[] {
   const out: number[] = [];
   for (let i = 0; i < G.cardsPlayedThisTurn.length; i++) {
@@ -279,6 +282,10 @@ function eotEligibleIndices(
     if (trigger.aspectFilter) {
       const data = lookupCard(c.deck, c.slot);
       if (data?.aspect !== trigger.aspectFilter) continue;
+    }
+    if (trigger.typeFilter) {
+      const data = lookupCard(c.deck, c.slot);
+      if (data?.type!== trigger.typeFilter) continue;
     }
     out.push(i);
   }
@@ -322,9 +329,19 @@ function startingDeck(): CardRef[] {
   if (!noble || !soldier) throw new Error('Starter deck missing Noble or Soldier');
   const nobleRef = toCardRef(noble.deck, noble.slot);
   const soldierRef = toCardRef(soldier.deck, soldier.slot);
-  const test_card = cardsInDeck('aberrations').find(c => c.name === 'Death Tyrant');
+  const test_card = cardsInDeck('undead').find(c => c.name === 'High Priest of Myrkul');
   const test_cardRef = toCardRef(test_card.deck, test_card.slot);
-  return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef),test_cardRef];
+  const test_card2 = cardsInDeck('undead').find(c => c.name === 'Conjurer');
+  const test_cardRef2 = toCardRef(test_card2.deck, test_card2.slot);
+  const test_card3 = cardsInDeck('undead').find(c => c.name === 'Wight');
+  const test_cardRef3 = toCardRef(test_card3.deck, test_card3.slot);
+  const test_card4 = cardsInDeck('undead').find(c => c.name === 'Ghost');
+  const test_cardRef4 = toCardRef(test_card4.deck, test_card4.slot);
+  const test_card5 = cardsInDeck('drow').find(c => c.name === 'Chosen of Lolth');
+  const test_cardRef5 = toCardRef(test_card5.deck, test_card5.slot);
+  //return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef),test_cardRef, test_card2, test_card3];
+  return [...Array(1).fill(nobleRef), test_cardRef, test_cardRef2, test_cardRef3, test_cardRef4];
+  //return [...Array(4).fill(nobleRef), test_cardRef5];
 }
 
 /** Encode the game state to a base64 JSON codec string, excluding the snapshots
@@ -779,6 +796,9 @@ export const TyrantsGame: Game<TyrantsState> = {
         // Trigger entries can include an optional aspectFilter (Air/Fire/Water
         // Myrmidons restrict to Obedience); eligible cards must also match
         // that aspect when the filter is set.
+        // Trigger entries can include an optional typeFilter (High Priest of
+        // Myrkul restrict to Undead); eligible cards must also match
+        // that type when the filter is set.
         while (G.pendingEotPromotions.length > 0) {
           const t = G.pendingEotPromotions[0];
           if (eotEligibleIndices(G, t).length > 0) break;
@@ -788,9 +808,15 @@ export const TyrantsGame: Game<TyrantsState> = {
           const t = G.pendingEotPromotions[0];
           const eligible = eotEligibleIndices(G, t);
           const aspectTag = t.aspectFilter ? ` ${t.aspectFilter}` : '';
+          const typeTag = t.typeFilter ? ` ${t.typeFilter}` : '';
+
+          if (t.typeFilter === 'Undead') {
+            G.pendingEotPromotions.length += (eligible.length - 1);
+          }
+
           G.pendingChoice = {
             kind: 'select-played-card',
-            prompt: `End of turn — promote ${t.optional ? 'an optional' : 'a'}${aspectTag} card played this turn — ${t.optional ? 'you may decline this one' : `${t.name} requires it, so you must promote one`} (triggered by ${t.name}; ${G.pendingEotPromotions.length} remaining).`,
+            prompt: `End of turn — promote ${t.optional ? 'an optional' : 'a'}${aspectTag}${typeTag} card played this turn — ${t.optional ? 'you may decline this one' : `${t.name} requires it, so you must promote one`} (triggered by ${t.name}; ${G.pendingEotPromotions.length} remaining).`,
             options: eligible,
             // Mandatory by default; only declinable when the trigger
             // explicitly says so (printed "you may promote..." cards).
@@ -1053,10 +1079,18 @@ export const TyrantsGame: Game<TyrantsState> = {
       if (G.pendingEotPromotions.length > 0) {
         const trigger = G.pendingEotPromotions[0];
         const eligible = eotEligibleIndices(G, trigger);
+        
+        if (trigger.typeFilter === 'Undead') {
+          G.pendingEotPromotions.length += (eligible.length - 1);
+        }
+
         if (eligible.length === 0) {
           // No eligible card to promote (either no other played card, or none
           // matching the trigger's aspectFilter) — drop this trigger and try
           // the next or finish.
+          if (trigger.typeFilter === 'Undead') {
+            Mechanics.log(G, '(High Priest of Myrkul: no Undead cards played this turn to promote)');
+          }
           G.pendingEotPromotions.shift();
           while (G.pendingEotPromotions.length > 0) {
             const t = G.pendingEotPromotions[0];
@@ -1068,9 +1102,10 @@ export const TyrantsGame: Game<TyrantsState> = {
         const trigger2 = G.pendingEotPromotions[0];
         const eligible2 = eotEligibleIndices(G, trigger2);
         const aspectTag = trigger2.aspectFilter ? ` ${trigger2.aspectFilter}` : '';
+        const typeTag = trigger2.typeFilter ? ` ${trigger2.typeFilter}` : '';
         G.pendingChoice = {
           kind: 'select-played-card',
-          prompt: `End of turn — promote ${trigger2.optional ? 'an optional' : 'a'}${aspectTag} card played this turn — ${trigger2.optional ? 'you may decline this one' : `${trigger2.name} requires it, so you must promote one`} (triggered by ${trigger2.name}; ${G.pendingEotPromotions.length} remaining).`,
+          prompt: `End of turn — promote ${trigger2.optional ? 'an optional' : 'a'}${aspectTag}${typeTag} card played this turn — ${trigger2.optional ? 'you may decline this one' : `${trigger2.name} requires it, so you must promote one`} (triggered by ${trigger2.name}; ${G.pendingEotPromotions.length} remaining).`,
           options: eligible2,
           // See companion site at the top of resolveChoice — mandatory by
           // default, declinable only when the trigger flags itself optional.

--- a/src/game.ts
+++ b/src/game.ts
@@ -322,7 +322,9 @@ function startingDeck(): CardRef[] {
   if (!noble || !soldier) throw new Error('Starter deck missing Noble or Soldier');
   const nobleRef = toCardRef(noble.deck, noble.slot);
   const soldierRef = toCardRef(soldier.deck, soldier.slot);
-  return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef)];
+  const test_card = cardsInDeck('aberrations').find(c => c.name === 'Death Tyrant');
+  const test_cardRef = toCardRef(test_card.deck, test_card.slot);
+  return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef),test_cardRef];
 }
 
 /** Encode the game state to a base64 JSON codec string, excluding the snapshots

--- a/src/game.ts
+++ b/src/game.ts
@@ -335,9 +335,9 @@ function startingDeck(): CardRef[] {
   const test_cardRef2 = toCardRef(test_card2.deck, test_card2.slot);
   const test_card3 = cardsInDeck('dragons').find(c => c.name === 'Blue Dragon');
   const test_cardRef3 = toCardRef(test_card3.deck, test_card3.slot);
-  const test_card4 = cardsInDeck('undead').find(c => c.name === 'Ghost');
+  const test_card4 = cardsInDeck('undead').find(c => c.name === 'Wight');
   const test_cardRef4 = toCardRef(test_card4.deck, test_card4.slot);
-  const test_card5 = cardsInDeck('drow').find(c => c.name === 'Council Member');
+  const test_card5 = cardsInDeck('undead').find(c => c.name === 'Ghost');
   const test_cardRef5 = toCardRef(test_card5.deck, test_card5.slot);
   //return [...Array(7).fill(nobleRef), ...Array(3).fill(soldierRef)];
   return [ ...Array(1).fill(nobleRef), test_cardRef, test_cardRef2, test_cardRef3, test_cardRef5];
@@ -793,6 +793,11 @@ export const TyrantsGame: Game<TyrantsState> = {
         // Consume the trigger we were responding to.
         const consumedTrigger = G.pendingEotPromotions.shift()!;
 
+        // Log when the player declined an optional promote.
+        if (idx == null && consumedTrigger.optional) {
+          Mechanics.log(G, `(end of turn: ${consumedTrigger.name} promote declined)`);
+        }
+
         // If the consumed trigger was an Undead-type repeating promote (High
         // Priest of Myrkul) AND the player just picked a card (didn't decline),
         // check whether more Undead cards remain eligible. If so, re-insert the
@@ -809,20 +814,27 @@ export const TyrantsGame: Game<TyrantsState> = {
         // followed by aspect=Obedience, then type=Undead, then optional.
         // This allows the player to selectively reduce promotes, if desired.
         G.pendingEotPromotions.sort((a, b) => {
-          const aObedience = a.aspectFilter === 'Obedience' ? 0 : 1;
-          const bObedience = b.aspectFilter === 'Obedience' ? 0 : 1;
-          const aUndead = a.typeFilter === 'Undead' ? 0 : 1;
-          const bUndead = b.typeFilter === 'Undead' ? 0 : 1;
-          const aOptional = a.optional === true ? 0 : 1;
-          const bOptional = b.optional === true ? 0 : 1;
-          return bObedience - aObedience || bUndead - aUndead || bOptional - aOptional;
+          const getPriority = (item) => {
+            // Bucket 1: Not optional and NO aspect
+            if (!item.optional && item.aspectFilter !== 'Obedience') return 1;
+            // Bucket 2: Not optional WITH aspect
+            if (!item.optional && item.aspectFilter === 'Obedience') return 2;
+            // Bucket 3: Optional WITH type
+            if (item.optional && item.typeFilter === 'Undead') return 3;
+            // Bucket 4: Optional with NO type and NO aspect
+            return 4;
+          };
+          // Sort ascending by priority score (1 comes before 2, etc.)
+          return getPriority(a) - getPriority(b);
         });
 
-        // Skip any subsequent triggers that have no other cards to promote.
+        // Skip any subsequent triggers that have no other cards to promote,
+        // logging each one that is silently dropped.
         while (G.pendingEotPromotions.length > 0) {
           const t = G.pendingEotPromotions[0];
           if (eotEligibleIndices(G, t).length > 0) break;
           G.pendingEotPromotions.shift();
+          Mechanics.log(G, `(end of turn: ${t.name} promote skipped — no eligible cards)`);
         }
         if (G.pendingEotPromotions.length > 0) {
           const t = G.pendingEotPromotions[0];
@@ -831,7 +843,7 @@ export const TyrantsGame: Game<TyrantsState> = {
           const typeTag = t.typeFilter ? ` ${t.typeFilter}` : '';
           G.pendingChoice = {
             kind: 'select-played-card',
-            prompt: `End of turn — promote ${t.optional ? 'an optional' : 'a'}${aspectTag}${typeTag} card played this turn — ${t.optional ? 'you may decline this one' : `${t.name} requires it, so you must promote one`} (triggered by ${t.name}; ${G.pendingEotPromotions.length} remaining).`,
+            prompt: `End of turn — promote ${t.typeFilter ? 'as many chosen': (t.optional ? 'an optional' : 'a')}${aspectTag}${typeTag} card played this turn — ${t.optional ? 'you may decline this one' : `${t.name} requires it, so you must promote one`} (triggered by ${t.name}; ${G.pendingEotPromotions.length} remaining).`,
             options: eligible,
             // Mandatory by default; only declinable when the trigger
             // explicitly says so (printed "you may promote..." cards).
@@ -1096,13 +1108,18 @@ export const TyrantsGame: Game<TyrantsState> = {
         // followed by aspect=Obedience, then type=Undead, then optional.
         // This allows the player to selectively reduce promotes, if desired.
         G.pendingEotPromotions.sort((a, b) => {
-          const aObedience = a.aspectFilter === 'Obedience' ? 0 : 1;
-          const bObedience = b.aspectFilter === 'Obedience' ? 0 : 1;
-          const aUndead = a.typeFilter === 'Undead' ? 0 : 1;
-          const bUndead = b.typeFilter === 'Undead' ? 0 : 1;
-          const aOptional = a.optional === true ? 0 : 1;
-          const bOptional = b.optional === true ? 0 : 1;
-          return bObedience - aObedience || bUndead - aUndead || bOptional - aOptional;
+          const getPriority = (item) => {
+            // Bucket 1: Not optional and NO aspect
+            if (!item.optional && item.aspectFilter !== 'Obedience') return 1;
+            // Bucket 2: Not optional WITH aspect
+            if (!item.optional && item.aspectFilter === 'Obedience') return 2;
+            // Bucket 3: Optional WITH type
+            if (item.optional && item.typeFilter === 'Undead') return 3;
+            // Bucket 4: Optional with NO type and NO aspect
+            return 4;
+          };
+          // Sort ascending by priority score (1 comes before 2, etc.)
+          return getPriority(a) - getPriority(b);
         });
 
         const trigger = G.pendingEotPromotions[0];
@@ -1112,10 +1129,12 @@ export const TyrantsGame: Game<TyrantsState> = {
           // matching the trigger's aspectFilter / typeFilter) — drop this trigger
           // and try the next or finish.
           G.pendingEotPromotions.shift();
+          Mechanics.log(G, `(end of turn: ${trigger.name} promote skipped — no eligible cards)`);
           while (G.pendingEotPromotions.length > 0) {
             const t = G.pendingEotPromotions[0];
             if (eotEligibleIndices(G, t).length > 0) break;
             G.pendingEotPromotions.shift();
+            Mechanics.log(G, `(end of turn: ${t.name} promote skipped — no eligible cards)`);
           }
           if (G.pendingEotPromotions.length === 0) { events.endTurn(); return; }
         }
@@ -1125,7 +1144,7 @@ export const TyrantsGame: Game<TyrantsState> = {
         const typeTag = trigger2.typeFilter ? ` ${trigger2.typeFilter}` : '';
         G.pendingChoice = {
           kind: 'select-played-card',
-          prompt: `End of turn — promote ${trigger2.optional ? 'an optional' : 'a'}${aspectTag}${typeTag} card played this turn — ${trigger2.optional ? 'you may decline this one' : `${trigger2.name} requires it, so you must promote one`} (triggered by ${trigger2.name}; ${G.pendingEotPromotions.length} remaining).`,
+          prompt: `End of turn — promote ${trigger2.typeFilter ? 'as many chosen': (trigger2.optional ? 'an optional' : 'a')}${aspectTag}${typeTag} card played this turn — ${trigger2.optional ? 'you may decline this one' : `${trigger2.name} requires it, so you must promote one`} (triggered by ${trigger2.name}; ${G.pendingEotPromotions.length} remaining).`,
           options: eligible2,
           // See companion site at the top of resolveChoice — mandatory by
           // default, declinable only when the trigger flags itself optional.


### PR DESCRIPTION
General changes made to cards include:

- benefit text edits for consistency and accuracy
- updates to handlers if a card's action is optional or not.
- cards with eotPromote triggers no longer play when selecting "Play all basic"
- sorted Promote triggers to allow player to selectively reduce promotes
- skipped or declined promotes appear in log
- hide ineligible cards when revealing to trigger focus

Specific card changes:

- Demogorgon: supplant requires presence
- Dragonclaw: power gained only for non-white trophies
- Necromancer: if promote is chosen, must promote.
- Minotaur Skeleton: restricted assassinate site to first chosen
- High Priest of Myrkul: added promote Undead filter
- Grimlock: deploy count corrected
- Intellect Devourer: text allows selection of own troops/spies and to be declined, fixed accordingly
- Death Tyrant: now awards player Influence per kill
- Mindwitness: fixed to force player of assasinated troop to discard, "undo" now rolls back to before assassination target
- Conjurer: now displays number of free recruits remaining

Changes have been tested a few times to verify, though only with AI.
Not sure on behaviour with multiple human players.
