### PR TITLE
spacesAdjacentTo logic fix and removed duplicate links in resource list.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1652,9 +1652,9 @@ export function Board({ G, ctx, moves }: BoardProps<TyrantsState>) {
         Player P{Number(me) + 1} ({p.color}) — Turn: P{Number(ctx.currentPlayer) + 1} {myTurn ? '(your turn)' : ''}
         {' · '}Power: {p.power} · Influence: {p.influence}
         {' · '}{pileButton('Deck', p.deck.length, () => { setPilePlayer(null); setPileView('deck'); })}
-        {' · '}{pileButton('Discard', p.discard.length, () => { setPilePlayer(null); setPileView('discard'); })}
+        {/* {' · '}{pileButton('Discard', p.discard.length, () => { setPilePlayer(null); setPileView('discard'); })}
         {' · '}{pileButton('Inner Circle', p.innerCircle.length, () => { setPilePlayer(null); setPileView('inner'); })}
-        {' · '}{pileButton('Trophies', Object.values(p.trophyHall).reduce((s, n) => s + n, 0), () => { setPilePlayer(null); setPileView('trophy'); })}
+        {' · '}{pileButton('Trophies', Object.values(p.trophyHall).reduce((s, n) => s + n, 0), () => { setPilePlayer(null); setPileView('trophy'); })} */}
         {' · '}Barracks: {p.barracksLeft} · Spies: {p.spiesLeft}
         {' · '}<b style={{ color: '#ffcc44' }}>VP: {p.vp}</b>
         {G.endGameTriggeredAtTurn !== null && <span style={{ color: '#ffcc44', marginLeft: 8 }}>· Final round!</span>}

--- a/src/engine/handler-helpers.ts
+++ b/src/engine/handler-helpers.ts
@@ -10,7 +10,7 @@ import type { EffectContext, EffectHandler, PendingChoice } from './types';
 import { placeSpy, assassinateTroop, deployTroop, hasPresence, returnSpy, returnTroop, moveTroop } from './map-state';
 import { SITES } from '../data/sites';
 import { ROUTES } from '../data/routes';
-import { TROOP_SPACES } from '../data/troop-spaces';
+import { TROOP_SPACES, routeSpaces, sitesSpaces } from '../data/troop-spaces';
 import { lookupCard, cardsInDeck } from '../card-data';
 import type { CardRef, Color, TyrantsState } from '../game';
 
@@ -1774,30 +1774,88 @@ export function recruitOutcastToSelf(): EffectHandler {
 // ---------- Adjacency-aware Outcast giver (Gibbering Mouther) ----------
 //
 // After a deploy, give an Outcast to a player who has a troop "adjacent" to the just-
-// deployed space. We define adjacency as: same site (for site spaces), the spaces of any
-// route touching that site, and (for route spaces) the same route's spaces and the two
-// endpoint sites' spaces.
+// deployed space. We define adjacency as: same site (for site spaces), exactly adjacent sites,
+// the nearest space of any route touching that site, and (for route spaces) the route spaces
+// directly before and after the deployed space, plus any site spaces if the deployed space
+// is at the end of a route.
 
-function spacesAdjacentTo(spaceId: string): string[] {
+export function spacesAdjacentTo(spaceId: string): string[] {
   const s = TROOP_SPACES.find(t => t.id === spaceId);
   if (!s) return [];
   const out = new Set<string>();
+
   if (s.parentSite) {
-    for (const t of TROOP_SPACES) if (t.parentSite === s.parentSite && t.id !== spaceId) out.add(t.id);
+    // 1. Other spaces at the exact same site
+    for (const t of TROOP_SPACES) {
+      if (t.parentSite === s.parentSite && t.id !== spaceId) {
+        out.add(t.id);
+      }
+    }
+    
+    // 2. Adjacent route spaces (strictly the endmost slot) OR adjacent sites
     for (const r of ROUTES) {
       if (r.a === s.parentSite || r.b === s.parentSite) {
-        for (let i = 0; i < r.spaces; i++) out.add(`${r.id}:${i}`);
+        const rSpaces = routeSpaces(r.id);
+        
+        if (rSpaces.length === 0) {
+          // Direct site-to-site connection (0 spaces)
+          const otherSite = r.a === s.parentSite ? r.b : r.a;
+          for (const t of sitesSpaces(otherSite)) out.add(t.id);
+        } else {
+          // Only add the immediately touching endmost route slot 
+          // (0 if it touches site A, N-1 if it touches site B)
+          const targetIdx = r.a === s.parentSite ? 0 : rSpaces.length - 1;
+          out.add(`${r.id}:${targetIdx}`);
+        }
       }
     }
   } else if (s.parentRoute) {
     const r = ROUTES.find(rr => rr.id === s.parentRoute)!;
-    for (let i = 0; i < r.spaces; i++) if (i !== s.index) out.add(`${r.id}:${i}`);
-    for (const endpoint of [r.a, r.b]) {
-      for (const t of TROOP_SPACES) if (t.parentSite === endpoint) out.add(t.id);
+    const rSpaces = routeSpaces(r.id);
+    const idx = s.index;
+
+    // 1. Immediately adjacent spaces on the same route
+    if (idx > 0) out.add(`${r.id}:${idx - 1}`);
+    if (idx < rSpaces.length - 1) out.add(`${r.id}:${idx + 1}`);
+
+    // 2. Endpoint sites, strictly if this is an endmost route space
+    if (idx === 0) {
+      for (const t of sitesSpaces(r.a)) out.add(t.id);
+    }
+    if (idx === rSpaces.length - 1) {
+      for (const t of sitesSpaces(r.b)) out.add(t.id);
     }
   }
+
   return [...out];
 }
+
+// ! Depreciated Method:
+// ! Incorrect implementation of adjacency; previous logic considered (for site spaces) all
+// ! spaces on routes connected to the deployed space's site as adjacent, and (for route spaces)
+// ! all spaces on the route plus all site spaces at both endpoints as adjacent. 
+// ! This was too broad and did not match the intended adjacency rules.
+// ! Method left here for reference.
+// function spacesAdjacentTo(spaceId: string): string[] {
+//   const s = TROOP_SPACES.find(t => t.id === spaceId);
+//   if (!s) return [];
+//   const out = new Set<string>();
+//   if (s.parentSite) {
+//     for (const t of TROOP_SPACES) if (t.parentSite === s.parentSite && t.id !== spaceId) out.add(t.id);
+//     for (const r of ROUTES) {
+//       if (r.a === s.parentSite || r.b === s.parentSite) {
+//         for (let i = 0; i < r.spaces; i++) out.add(`${r.id}:${i}`);
+//       }
+//     }
+//   } else if (s.parentRoute) {
+//     const r = ROUTES.find(rr => rr.id === s.parentRoute)!;
+//     for (let i = 0; i < r.spaces; i++) if (i !== s.index) out.add(`${r.id}:${i}`);
+//     for (const endpoint of [r.a, r.b]) {
+//       for (const t of TROOP_SPACES) if (t.parentSite === endpoint) out.add(t.id);
+//     }
+//   }
+//   return [...out];
+// }
 
 export function giveOutcastToOpponentAdjacentToLastDeploy(): EffectHandler {
   return ctx => {


### PR DESCRIPTION
spacesAdjacentTo logic fix
Previous logic included:
- if deployed at site, all spaces along routes connected to site;
- if deployed on route, all spaces on route and sites at both ends.

New logic now should only include:
- if deployed at site, site spaces at site or at site directly connected to deployed space, and route spaces directly connected to deployed site;
- if deployed on route, route spaces either side of deployed space, and site spaces if deployed space was an endpoint.

Additional change:
Commented out links that were duplicated in the Scoreboard, for better UI
Player information display (power, influence, deck, barracks, spies, VP(?)), can now be seen as resource tracker.
Scoreboard displays (VP, site markers, discard, inner-circle, trophies, barracks), can now been seen as game progress tracker